### PR TITLE
feat: resize intro video in header

### DIFF
--- a/assets/css/treasury-portal.css
+++ b/assets/css/treasury-portal.css
@@ -195,6 +195,20 @@
             font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
         }
 
+        .treasury-portal .intro-video-target {
+            flex: 1;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .treasury-portal .intro-video-target video {
+            width: 200px;
+            max-width: 100%;
+            height: auto;
+            border-radius: 8px;
+        }
+
         /* Stats Cards */
         .treasury-portal .stats-bar {
             display: flex;


### PR DESCRIPTION
## Summary
- center intro video between title and stats in portal header
- constrain intro video size for better layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e218a374c833197e27d5bbca3926c