### PR TITLE
Add Cash Tools video preview and modal poster support

### DIFF
--- a/assets/css/treasury-portal.css
+++ b/assets/css/treasury-portal.css
@@ -209,6 +209,20 @@
             border-radius: 8px;
         }
 
+        .treasury-portal .category-video-target {
+            flex: 1;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .treasury-portal .category-video-target video {
+            width: 200px;
+            max-width: 100%;
+            height: auto;
+            border-radius: 8px;
+        }
+
         /* Stats Cards */
         .treasury-portal .stats-bar {
             display: flex;

--- a/assets/js/treasury-portal.js
+++ b/assets/js/treasury-portal.js
@@ -391,7 +391,8 @@ document.addEventListener('DOMContentLoaded', () => {
                             "Cash Visibility",
                             "Transaction Search, Sort, Tag, Group"
                         ],
-                        videoUrl: ""
+                        videoUrl: "https://realtreasury.com/wp-content/uploads/2025/08/Cash-Tools-Intro.mp4",
+                        videoPoster: "https://realtreasury.com/wp-content/uploads/2025/08/Cash-Tools-Intro.png"
                     },
                     LITE: {
                         name: "Treasury Management System Lite (TMS-Lite)",
@@ -859,6 +860,23 @@ document.addEventListener('DOMContentLoaded', () => {
                     showFallback();
                 }
 
+                document.querySelectorAll('.category-video-target').forEach((el) => {
+                    const categorySrc = el.getAttribute('data-video-src');
+                    const poster = el.getAttribute('data-poster');
+                    if (categorySrc) {
+                        const vid = document.createElement('video');
+                        vid.src = categorySrc;
+                        vid.controls = true;
+                        vid.autoplay = false;
+                        vid.playsInline = true;
+                        vid.preload = 'metadata';
+                        if (poster) vid.poster = poster;
+                        vid.setAttribute('playsinline', '');
+                        el.innerHTML = '';
+                        el.appendChild(vid);
+                    }
+                });
+
                 // Setup swipe-to-close for tool modal
                 this.setupSwipeToClose('toolModal', 'toolModal', () => this.closeModal('toolModal'));
 
@@ -1095,21 +1113,30 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (categoryInfo.videoUrl && modalBody) {
                     const videoSection = document.createElement('div');
                     videoSection.className = 'feature-section video-demo-section';
-
-                    let embedUrl = categoryInfo.videoUrl;
-                    if (categoryInfo.videoUrl.includes('youtu.be/')) {
-                        const videoId = categoryInfo.videoUrl.split('youtu.be/')[1].split('?')[0];
-                        embedUrl = `https://www.youtube.com/embed/${videoId}`;
-                    } else if (categoryInfo.videoUrl.includes('youtube.com/watch')) {
-                        const videoId = new URL(categoryInfo.videoUrl).searchParams.get('v');
-                        embedUrl = `https://www.youtube.com/embed/${videoId}`;
+                    let contentHtml = '';
+                    if (categoryInfo.videoUrl.includes('youtu.be/') || categoryInfo.videoUrl.includes('youtube.com/watch')) {
+                        let embedUrl = categoryInfo.videoUrl;
+                        if (categoryInfo.videoUrl.includes('youtu.be/')) {
+                            const videoId = categoryInfo.videoUrl.split('youtu.be/')[1].split('?')[0];
+                            embedUrl = `https://www.youtube.com/embed/${videoId}`;
+                        } else if (categoryInfo.videoUrl.includes('youtube.com/watch')) {
+                            const videoId = new URL(categoryInfo.videoUrl).searchParams.get('v');
+                            embedUrl = `https://www.youtube.com/embed/${videoId}`;
+                        }
+                        embedUrl += (embedUrl.includes('?') ? '&' : '?') + 'enablejsapi=1&playsinline=1';
+                        contentHtml = `<iframe src="${embedUrl}" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy" playsinline></iframe>`;
+                    } else {
+                        const posterAttr = categoryInfo.videoPoster ? ` poster="${categoryInfo.videoPoster}"` : '';
+                        contentHtml = `<video controls preload="metadata"${posterAttr}>
+                                        <source src="${categoryInfo.videoUrl}" type="video/mp4">
+                                        Your browser does not support the video tag.
+                                      </video>`;
                     }
-                    embedUrl += (embedUrl.includes('?') ? '&' : '?') + 'enablejsapi=1&playsinline=1';
 
                     videoSection.innerHTML = `
                         <h4>🎥 Category Overview Video</h4>
                         <div class="video-container">
-                             <iframe src="${embedUrl}" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy" playsinline></iframe>
+                             ${contentHtml}
                         </div>
                     `;
 

--- a/includes/shortcode.php
+++ b/includes/shortcode.php
@@ -196,6 +196,7 @@ if ($video_url && !wp_http_validate_url($video_url)) {
                         <span class="count-number" id="count-CASH">10</span>
                         <span class="count-label">Solutions</span>
                     </div>
+                    <div class="category-video-target" data-video-src="https://realtreasury.com/wp-content/uploads/2025/08/Cash-Tools-Intro.mp4" data-poster="https://realtreasury.com/wp-content/uploads/2025/08/Cash-Tools-Intro.png"></div>
                 </div>
                 <div class="tools-grid" id="tools-CASH">
                     <!-- Tools will be populated by JavaScript -->


### PR DESCRIPTION
## Summary
- Embed video preview container in Cash Tools header
- Mirror intro-video styles for category previews
- Render category video previews and modal posters with new JS

## Testing
- `php -l includes/shortcode.php`
- `node --check assets/js/treasury-portal.js`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0efa7ac0883318a6159baaa10f3b5