### PR TITLE
Add TMS-Lite category video preview and modal poster

### DIFF
--- a/assets/css/treasury-portal.css
+++ b/assets/css/treasury-portal.css
@@ -203,8 +203,8 @@
         }
 
         .treasury-portal .intro-video-target video {
-            width: 200px;
-            max-width: 100%;
+            max-width: 200px;
+            width: 100%;
             height: auto;
             border-radius: 8px;
         }
@@ -217,8 +217,8 @@
         }
 
         .treasury-portal .category-video-target video {
-            width: 200px;
-            max-width: 100%;
+            max-width: 200px;
+            width: 100%;
             height: auto;
             border-radius: 8px;
         }

--- a/assets/js/treasury-portal.js
+++ b/assets/js/treasury-portal.js
@@ -407,7 +407,8 @@ document.addEventListener('DOMContentLoaded', () => {
                             "Market Data",
                             "Treasury Payments (API, SFTP)"
                         ],
-                        videoUrl: ""
+                        videoUrl: "https://realtreasury.com/wp-content/uploads/2025/08/TMS-Lite-Intro.mp4",
+                        videoPoster: "https://realtreasury.com/wp-content/uploads/2025/08/TMS-Lite-Intro.png"
                     },
                     TRMS: {
                         name: "Treasury & Risk Management Systems (TRMS)",

--- a/includes/shortcode.php
+++ b/includes/shortcode.php
@@ -220,6 +220,7 @@ if ($video_url && !wp_http_validate_url($video_url)) {
                         <span class="count-number" id="count-LITE">6</span>
                         <span class="count-label">Solutions</span>
                     </div>
+                    <div class="category-video-target" data-video-src="https://realtreasury.com/wp-content/uploads/2025/08/TMS-Lite-Intro.mp4" data-poster="https://realtreasury.com/wp-content/uploads/2025/08/TMS-Lite-Intro.png"></div>
                 </div>
                 <div class="tools-grid" id="tools-LITE">
                     <!-- Tools will be populated by JavaScript -->


### PR DESCRIPTION
## Summary
- Add preview video container for the TMS-Lite category with preconfigured source and poster.
- Style category video targets to mirror intro video layout.
- Populate TMS-Lite category data with video URL and poster for consistent modal previews.

## Testing
- `./scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a0f7936a2c8331882eb7b1920a63f9