### PR TITLE
Add TRMS category video preview

### DIFF
--- a/assets/css/treasury-portal.css
+++ b/assets/css/treasury-portal.css
@@ -195,20 +195,7 @@
             font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
         }
 
-        .treasury-portal .intro-video-target {
-            flex: 1;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-
-        .treasury-portal .intro-video-target video {
-            width: 200px;
-            max-width: 100%;
-            height: auto;
-            border-radius: 8px;
-        }
-
+        .treasury-portal .intro-video-target,
         .treasury-portal .category-video-target {
             flex: 1;
             display: flex;
@@ -216,9 +203,10 @@
             justify-content: center;
         }
 
+        .treasury-portal .intro-video-target video,
         .treasury-portal .category-video-target video {
-            width: 200px;
-            max-width: 100%;
+            width: 100%;
+            max-width: 200px;
             height: auto;
             border-radius: 8px;
         }

--- a/assets/js/treasury-portal.js
+++ b/assets/js/treasury-portal.js
@@ -436,7 +436,8 @@ document.addEventListener('DOMContentLoaded', () => {
                             "Investments",
                             "SWIFT Connectivity"
                         ],
-                        videoUrl: ""
+                        videoUrl: "https://realtreasury.com/wp-content/uploads/2025/08/TRMS-Intro.mp4",
+                        videoPoster: "https://realtreasury.com/wp-content/uploads/2025/08/TRMS-Intro.png"
                     }
                 };
 
@@ -1127,7 +1128,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         contentHtml = `<iframe src="${embedUrl}" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy" playsinline></iframe>`;
                     } else {
                         const posterAttr = categoryInfo.videoPoster ? ` poster="${categoryInfo.videoPoster}"` : '';
-                        contentHtml = `<video controls preload="metadata"${posterAttr}>
+                        contentHtml = `<video controls preload="metadata"${posterAttr} playsinline>
                                         <source src="${categoryInfo.videoUrl}" type="video/mp4">
                                         Your browser does not support the video tag.
                                       </video>`;

--- a/includes/shortcode.php
+++ b/includes/shortcode.php
@@ -243,6 +243,7 @@ if ($video_url && !wp_http_validate_url($video_url)) {
                         <span class="count-number" id="count-TRMS">11</span>
                         <span class="count-label">Solutions</span>
                     </div>
+                    <div class="category-video-target" data-video-src="https://realtreasury.com/wp-content/uploads/2025/08/TRMS-Intro.mp4" data-poster="https://realtreasury.com/wp-content/uploads/2025/08/TRMS-Intro.png"></div>
                 </div>
                 <div class="tools-grid" id="tools-TRMS">
                     <!-- Tools will be populated by JavaScript -->


### PR DESCRIPTION
## Summary
- embed TRMS intro preview container in category header
- style category video containers like intro preview
- configure TRMS category with video URL/poster and ensure modal video uses poster

## Testing
- `./scripts/test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a0f83377448331a4739a6bb168d648