### PR TITLE
Add TRMS category video preview

### DIFF
--- a/assets/css/treasury-portal.css
+++ b/assets/css/treasury-portal.css
@@ -209,6 +209,7 @@
             border-radius: 8px;
         }
 
+        /* Category preview video container */
         .treasury-portal .category-video-target {
             flex: 1;
             display: flex;

--- a/assets/js/treasury-portal.js
+++ b/assets/js/treasury-portal.js
@@ -437,7 +437,8 @@ document.addEventListener('DOMContentLoaded', () => {
                             "Investments",
                             "SWIFT Connectivity"
                         ],
-                        videoUrl: ""
+                        videoUrl: "https://realtreasury.com/wp-content/uploads/2025/08/TRMS-Intro.mp4",
+                        videoPoster: "https://realtreasury.com/wp-content/uploads/2025/08/TRMS-Intro.png"
                     }
                 };
 
@@ -1128,7 +1129,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         contentHtml = `<iframe src="${embedUrl}" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy" playsinline></iframe>`;
                     } else {
                         const posterAttr = categoryInfo.videoPoster ? ` poster="${categoryInfo.videoPoster}"` : '';
-                        contentHtml = `<video controls preload="metadata"${posterAttr}>
+                        contentHtml = `<video controls preload="metadata"${posterAttr} playsinline>
                                         <source src="${categoryInfo.videoUrl}" type="video/mp4">
                                         Your browser does not support the video tag.
                                       </video>`;

--- a/includes/shortcode.php
+++ b/includes/shortcode.php
@@ -244,6 +244,7 @@ if ($video_url && !wp_http_validate_url($video_url)) {
                         <span class="count-number" id="count-TRMS">11</span>
                         <span class="count-label">Solutions</span>
                     </div>
+                    <div class="category-video-target" data-video-src="https://realtreasury.com/wp-content/uploads/2025/08/TRMS-Intro.mp4" data-poster="https://realtreasury.com/wp-content/uploads/2025/08/TRMS-Intro.png"></div>
                 </div>
                 <div class="tools-grid" id="tools-TRMS">
                     <!-- Tools will be populated by JavaScript -->


### PR DESCRIPTION
## Summary
- Embed TRMS category video container in shortcode markup
- Document category video container style for consistent preview formatting
- Link TRMS category info to intro video and poster, using playsinline when rendering in modal

## Testing
- `php -l includes/shortcode.php`
- `node --check assets/js/treasury-portal.js`

------
https://chatgpt.com/codex/tasks/task_e_68a0f9aae4308331b4191465fc333efa