### PR TITLE
Hide intro video controls until hover

### DIFF
--- a/assets/css/treasury-portal.css
+++ b/assets/css/treasury-portal.css
@@ -2262,3 +2262,44 @@
         padding-bottom: 80px !important;
     }
 }
+
+/* Hide video controls by default for all intro videos */
+.intro-video-target video,
+.category-video-target video {
+    /* Hide default browser controls */
+}
+
+.intro-video-target video::-webkit-media-controls,
+.category-video-target video::-webkit-media-controls {
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.intro-video-target video::-webkit-media-controls-panel,
+.category-video-target video::-webkit-media-controls-panel {
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+/* Show controls on hover */
+.intro-video-target:hover video::-webkit-media-controls,
+.category-video-target:hover video::-webkit-media-controls {
+    opacity: 1;
+}
+
+.intro-video-target:hover video::-webkit-media-controls-panel,
+.category-video-target:hover video::-webkit-media-controls-panel {
+    opacity: 1;
+}
+
+/* Firefox support */
+.intro-video-target video::-moz-media-controls,
+.category-video-target video::-moz-media-controls {
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.intro-video-target:hover video::-moz-media-controls,
+.category-video-target:hover video::-moz-media-controls {
+    opacity: 1;
+}


### PR DESCRIPTION
## Summary
- hide video controls by default for intro and category videos
- show controls when hovering videos, with WebKit and Firefox support

## Testing
- `scripts/test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a0fafea4808331ad6b875c152c1d51