### PR TITLE
Align category tool counts with intro videos

### DIFF
--- a/assets/css/treasury-portal.css
+++ b/assets/css/treasury-portal.css
@@ -211,10 +211,11 @@
 
         /* Category preview video container */
         .treasury-portal .category-video-target {
-            flex: 1;
+            flex: 0 0 auto;
             display: flex;
             align-items: center;
             justify-content: center;
+            margin-left: 20px;
         }
 
         .treasury-portal .category-video-target video {
@@ -359,7 +360,7 @@
         .treasury-portal .category-header {
             display: flex;
             align-items: center;
-            justify-content: space-between;
+            justify-content: flex-start;
             margin-bottom: 25px;
             padding-bottom: 15px;
             border-bottom: 1px solid #f3f4f6;
@@ -486,6 +487,7 @@
             padding: 15px;
             text-align: center;
             min-width: 100px;
+            margin-left: auto;
         }
 
         .treasury-portal .count-number {
@@ -1166,6 +1168,11 @@
                 flex-direction: column;
                 align-items: stretch;
                 gap: 15px;
+            }
+
+            .treasury-portal .category-video-target,
+            .treasury-portal .category-count {
+                margin-left: 0;
             }
 
             .treasury-portal .category-count {

--- a/includes/shortcode.php
+++ b/includes/shortcode.php
@@ -192,11 +192,11 @@ if ($video_url && !wp_http_validate_url($video_url)) {
                         </p>
                         <div class="category-tags" id="category-tags-CASH"></div>
                     </div>
+                    <div class="category-video-target" data-video-src="https://realtreasury.com/wp-content/uploads/2025/08/Cash-Tools-Intro.mp4" data-poster="https://realtreasury.com/wp-content/uploads/2025/08/Cash-Tools-Intro.png"></div>
                     <div class="category-count">
                         <span class="count-number" id="count-CASH">10</span>
                         <span class="count-label">Solutions</span>
                     </div>
-                    <div class="category-video-target" data-video-src="https://realtreasury.com/wp-content/uploads/2025/08/Cash-Tools-Intro.mp4" data-poster="https://realtreasury.com/wp-content/uploads/2025/08/Cash-Tools-Intro.png"></div>
                 </div>
                 <div class="tools-grid" id="tools-CASH">
                     <!-- Tools will be populated by JavaScript -->
@@ -216,11 +216,11 @@ if ($video_url && !wp_http_validate_url($video_url)) {
                         </p>
                         <div class="category-tags" id="category-tags-LITE"></div>
                     </div>
+                    <div class="category-video-target" data-video-src="https://realtreasury.com/wp-content/uploads/2025/08/TMS-Lite-Intro.mp4" data-poster="https://realtreasury.com/wp-content/uploads/2025/08/TMS-Lite-Intro.png"></div>
                     <div class="category-count">
                         <span class="count-number" id="count-LITE">6</span>
                         <span class="count-label">Solutions</span>
                     </div>
-                    <div class="category-video-target" data-video-src="https://realtreasury.com/wp-content/uploads/2025/08/TMS-Lite-Intro.mp4" data-poster="https://realtreasury.com/wp-content/uploads/2025/08/TMS-Lite-Intro.png"></div>
                 </div>
                 <div class="tools-grid" id="tools-LITE">
                     <!-- Tools will be populated by JavaScript -->
@@ -240,11 +240,11 @@ if ($video_url && !wp_http_validate_url($video_url)) {
                         </p>
                         <div class="category-tags" id="category-tags-TRMS"></div>
                     </div>
+                    <div class="category-video-target" data-video-src="https://realtreasury.com/wp-content/uploads/2025/08/TRMS-Intro.mp4" data-poster="https://realtreasury.com/wp-content/uploads/2025/08/TRMS-Intro.png"></div>
                     <div class="category-count">
                         <span class="count-number" id="count-TRMS">11</span>
                         <span class="count-label">Solutions</span>
                     </div>
-                    <div class="category-video-target" data-video-src="https://realtreasury.com/wp-content/uploads/2025/08/TRMS-Intro.mp4" data-poster="https://realtreasury.com/wp-content/uploads/2025/08/TRMS-Intro.png"></div>
                 </div>
                 <div class="tools-grid" id="tools-TRMS">
                     <!-- Tools will be populated by JavaScript -->


### PR DESCRIPTION
## Summary
- Display each category's intro video before its count card
- Push category tool counts to the far right and adjust layout spacing

## Testing
- `php -l includes/shortcode.php`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0fbcc98548331ab15aa66926219fa