### PR TITLE
Add spacing between category video and count cards

### DIFF
--- a/assets/css/treasury-portal.css
+++ b/assets/css/treasury-portal.css
@@ -215,11 +215,12 @@
             display: flex;
             align-items: center;
             justify-content: center;
-            margin-left: 20px;
+            max-width: 350px;
+            width: 100%;
         }
 
         .treasury-portal .category-video-target video {
-            max-width: 200px;
+            max-width: 350px;
             width: 100%;
             height: auto;
             border-radius: 8px;
@@ -359,8 +360,9 @@
 
         .treasury-portal .category-header {
             display: flex;
-            align-items: center;
+            align-items: flex-start;
             justify-content: flex-start;
+            gap: 2rem;
             margin-bottom: 25px;
             padding-bottom: 15px;
             border-bottom: 1px solid #f3f4f6;
@@ -377,6 +379,42 @@
 
         .treasury-portal .category-info {
             flex: 1;
+            min-width: 0;
+        }
+
+        /* Container for video and count card on the right */
+        .treasury-portal .category-header .category-right {
+            display: flex;
+            align-items: flex-start;
+            gap: 1.5rem; /* Space between video and count card */
+            flex-shrink: 0;
+        }
+
+        /* Style the count card container */
+        .treasury-portal .category-header .solutions-count,
+        .treasury-portal .category-header .category-count {
+            margin-left: 1.5rem; /* Additional spacing from video */
+            flex-shrink: 0;
+        }
+
+        /* Ensure video maintains its size */
+        .treasury-portal .category-video-target {
+            max-width: 350px;
+            width: 100%;
+        }
+
+        /* Responsive adjustments */
+        @media (max-width: 768px) {
+            .treasury-portal .category-header .category-right {
+                flex-direction: column;
+                gap: 1rem;
+                align-items: center;
+            }
+
+            .treasury-portal .category-header .solutions-count,
+            .treasury-portal .category-header .category-count {
+                margin-left: 0;
+            }
         }
 
         .treasury-portal .category-title {


### PR DESCRIPTION
## Summary
- adjust category video container width
- add layout rules for spacing between category video and count cards with responsive tweaks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0fd72d5748331b599dbc405b5999b