### PR TITLE
Add poster image to portal intro video

### DIFF
--- a/assets/js/treasury-portal.js
+++ b/assets/js/treasury-portal.js
@@ -837,7 +837,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
                 const container = document.querySelector('.treasury-portal');
                 const target = container?.querySelector('.intro-video-target') || container;
-                const src = container?.getAttribute('data-video-src') || '';
+                const src = target?.getAttribute('data-video-src') || '';
+                const poster = target?.getAttribute('data-poster') || '';
 
                 const showFallback = () => {
                     target.innerHTML = '<div class="intro-video-fallback">Intro video unavailable</div>';
@@ -847,17 +848,17 @@ document.addEventListener('DOMContentLoaded', () => {
                     const video = document.createElement('video');
                     video.src = src;
                     video.controls = true;
-                    video.autoplay = true;
+                    video.autoplay = false;
                     video.muted = false;
                     video.playsInline = true;
                     video.preload = 'metadata';
                     video.setAttribute('playsinline', '');
+                    if (poster) video.poster = poster;
 
                     video.onerror = showFallback;
 
                     target.innerHTML = '';
                     target.appendChild(video);
-                    video.play().catch(() => {});
                 } else {
                     showFallback();
                 }

--- a/includes/shortcode.php
+++ b/includes/shortcode.php
@@ -5,12 +5,16 @@ if (!defined("ABSPATH")) exit;
 $video_url = defined('TTP_INTRO_VIDEO_URL')
     ? TTP_INTRO_VIDEO_URL
     : get_option('ttp_intro_video_url', '');
+$poster_url = 'https://realtreasury.com/wp-content/uploads/2025/08/Portal-Intro.png';
 
 if ($video_url && !wp_http_validate_url($video_url)) {
     $video_url = '';
 }
+if ($poster_url && !wp_http_validate_url($poster_url)) {
+    $poster_url = '';
+}
 ?>
-<div class="treasury-portal" data-video-src="<?php echo esc_url($video_url); ?>">
+<div class="treasury-portal">
     <div class="container">
         <button class="external-menu-toggle" id="externalMenuToggle">Menu</button>
         <button class="external-shortlist-toggle" id="externalShortlistToggle" aria-label="Open shortlist menu" title="Shortlist">Shortlist</button>
@@ -31,7 +35,7 @@ if ($video_url && !wp_http_validate_url($video_url)) {
                     </div>
                 </div>
 
-                <div class="intro-video-target"></div>
+                <div class="intro-video-target" data-video-src="<?php echo esc_url($video_url); ?>" data-poster="<?php echo esc_url($poster_url); ?>"></div>
 
                 <div class="stats-bar">
                     <div class="stat-card">


### PR DESCRIPTION
## Summary
- Allow intro video HTML container to specify poster image through new `data-poster` attribute.
- Update portal script to read poster data attribute, disable autoplay, and apply poster image before playback.

## Testing
- `node --check assets/js/treasury-portal.js`
- `php -l includes/shortcode.php`


------
https://chatgpt.com/codex/tasks/task_e_68a0fdc25f0c8331a1bc68c3f6dcc728