### PR TITLE
Add desktop side text labels for menu and shortlist

### DIFF
--- a/assets/css/treasury-portal.css
+++ b/assets/css/treasury-portal.css
@@ -2420,3 +2420,51 @@
 .category-video-target:hover video::-moz-media-controls {
     opacity: 1;
 }
+/* Rotated side text labels */
+.treasury-portal .side-text-label {
+    position: fixed;
+    top: 50%;
+    transform: translateY(-50%);
+    writing-mode: vertical-rl;
+    text-orientation: mixed;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: rgba(114, 22, 244, 0.7);
+    letter-spacing: 0.1em;
+    pointer-events: none;
+    z-index: 998;
+    user-select: none;
+    transition: opacity 0.3s ease, color 0.3s ease;
+}
+
+.treasury-portal .side-text-menu {
+    left: 8px;
+}
+
+.treasury-portal .side-text-shortlist {
+    right: 8px;
+}
+
+/* Fade effect when menus are open */
+.treasury-portal.side-menu-open .side-text-menu,
+.treasury-portal.shortlist-menu-open .side-text-shortlist {
+    opacity: 0.3;
+}
+
+/* Hide on mobile where we have bottom navigation */
+@media (max-width: 768px) {
+    .treasury-portal .side-text-label {
+        display: none;
+    }
+}
+
+/* Adjust positioning when external toggles are visible */
+@media (min-width: 769px) {
+    .treasury-portal .side-text-menu {
+        left: 12px;
+    }
+    
+    .treasury-portal .side-text-shortlist {
+        right: 12px;
+    }
+}

--- a/assets/js/treasury-portal.js
+++ b/assets/js/treasury-portal.js
@@ -527,6 +527,12 @@ document.addEventListener('DOMContentLoaded', () => {
                     this.closeSideMenu();
                     this.closeShortlistMenu();
 
+                    // Hide side text labels on mobile
+                    const menuText = document.getElementById('sideTextMenu');
+                    const shortlistText = document.getElementById('sideTextShortlist');
+                    if (menuText) menuText.style.display = 'none';
+                    if (shortlistText) shortlistText.style.display = 'none';
+
                     const externalMenuToggle = document.getElementById('externalMenuToggle');
                     const externalShortlistToggle = document.getElementById('externalShortlistToggle');
                     if (externalMenuToggle) externalMenuToggle.style.display = 'none';
@@ -535,6 +541,12 @@ document.addEventListener('DOMContentLoaded', () => {
                     const bottomNav = document.getElementById('bottomNav');
                     if (bottomNav) bottomNav.style.display = 'flex';
                 } else {
+                    // Show side text labels on desktop
+                    const menuText = document.getElementById('sideTextMenu');
+                    const shortlistText = document.getElementById('sideTextShortlist');
+                    if (menuText) menuText.style.display = 'block';
+                    if (shortlistText) shortlistText.style.display = 'block';
+
                     const externalMenuToggle = document.getElementById('externalMenuToggle');
                     const externalShortlistToggle = document.getElementById('externalShortlistToggle');
                     if (externalMenuToggle) externalMenuToggle.style.display = 'flex';
@@ -555,6 +567,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 this.setupSideMenu();
                 this.setupShortlistMenu();
                 this.setupBottomNav();
+                this.setupSideTextLabels(); // Add this line
                 this.updateCounts();
                 this.populateCategoryTags();
                 this.filterAndDisplayTools();
@@ -1522,6 +1535,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 const featureCheckboxes = document.querySelectorAll('#tagFilters input[type="checkbox"]');
                 featureCheckboxes.forEach(cb => {
                     cb.addEventListener('change', () => {
+
                         this.updateFeatureFilters();
                         this.filterAndDisplayTools();
                         this.updateFilterCount();
@@ -2075,6 +2089,17 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
             }
 
+
+            setupSideTextLabels() {
+                if (this.isMobile()) return; // Skip on mobile
+                
+                const menuText = document.getElementById('sideTextMenu');
+                const shortlistText = document.getElementById('sideTextShortlist');
+                
+                // Show labels on desktop
+                if (menuText) menuText.style.display = 'block';
+                if (shortlistText) shortlistText.style.display = 'block';
+            }
 
             updateFeatureFilters() {
                 const cbs = document.querySelectorAll('#tagFilters input[type="checkbox"]');

--- a/includes/shortcode.php
+++ b/includes/shortcode.php
@@ -15,6 +15,9 @@ if ($poster_url && !wp_http_validate_url($poster_url)) {
 }
 ?>
 <div class="treasury-portal">
+    <!-- Rotated side text labels -->
+    <div class="side-text-label side-text-menu" id="sideTextMenu">MENU</div>
+    <div class="side-text-label side-text-shortlist" id="sideTextShortlist">SHORTLIST</div>
     <div class="container">
         <button class="external-menu-toggle" id="externalMenuToggle">Menu</button>
         <button class="external-shortlist-toggle" id="externalShortlistToggle" aria-label="Open shortlist menu" title="Shortlist">Shortlist</button>


### PR DESCRIPTION
## Summary
- show rotated "MENU" and "SHORTLIST" labels on desktop edges
- hide/show labels responsively and expose `setupSideTextLabels` helper
- fade side labels when corresponding menus open

## Testing
- `scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a10876228c833180c9c7132863d5f6