### PR TITLE
Hide default controls on intro videos

### DIFF
--- a/assets/css/treasury-portal.css
+++ b/assets/css/treasury-portal.css
@@ -2393,43 +2393,17 @@
     width: inherit;
 }
 
-/* Hide video controls by default for all intro videos */
+/* Hide video controls for all intro videos */
 .intro-video-target video,
 .category-video-target video {
-    /* Hide default browser controls */
+    /* Controls removed via JS; keep fallback hidden */
 }
 
 .intro-video-target video::-webkit-media-controls,
-.category-video-target video::-webkit-media-controls {
-    opacity: 0;
-    transition: opacity 0.3s ease;
-}
-
+.category-video-target video::-webkit-media-controls,
 .intro-video-target video::-webkit-media-controls-panel,
-.category-video-target video::-webkit-media-controls-panel {
-    opacity: 0;
-    transition: opacity 0.3s ease;
-}
-
-/* Show controls on hover */
-.intro-video-target:hover video::-webkit-media-controls,
-.category-video-target:hover video::-webkit-media-controls {
-    opacity: 1;
-}
-
-.intro-video-target:hover video::-webkit-media-controls-panel,
-.category-video-target:hover video::-webkit-media-controls-panel {
-    opacity: 1;
-}
-
-/* Firefox support */
+.category-video-target video::-webkit-media-controls-panel,
 .intro-video-target video::-moz-media-controls,
 .category-video-target video::-moz-media-controls {
     opacity: 0;
-    transition: opacity 0.3s ease;
-}
-
-.intro-video-target:hover video::-moz-media-controls,
-.category-video-target:hover video::-moz-media-controls {
-    opacity: 1;
 }

--- a/assets/js/treasury-portal.js
+++ b/assets/js/treasury-portal.js
@@ -847,13 +847,20 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (src) {
                     const video = document.createElement('video');
                     video.src = src;
-                    video.controls = true;
                     video.autoplay = false;
                     video.muted = false;
                     video.playsInline = true;
                     video.preload = 'metadata';
                     video.setAttribute('playsinline', '');
                     if (poster) video.poster = poster;
+
+                    video.addEventListener('click', () => {
+                        if (video.paused) {
+                            video.play();
+                        } else {
+                            video.pause();
+                        }
+                    });
 
                     video.onerror = showFallback;
 
@@ -869,12 +876,18 @@ document.addEventListener('DOMContentLoaded', () => {
                     if (categorySrc) {
                         const vid = document.createElement('video');
                         vid.src = categorySrc;
-                        vid.controls = true;
                         vid.autoplay = false;
                         vid.playsInline = true;
                         vid.preload = 'metadata';
                         if (poster) vid.poster = poster;
                         vid.setAttribute('playsinline', '');
+                        vid.addEventListener('click', () => {
+                            if (vid.paused) {
+                                vid.play();
+                            } else {
+                                vid.pause();
+                            }
+                        });
                         el.innerHTML = '';
                         el.appendChild(vid);
                     }


### PR DESCRIPTION
## Summary
- Remove built-in controls from intro and category videos and enable click-to-play
- Keep browser controls hidden in CSS so videos show without captions or titles

## Testing
- `bash scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a11309232c83318236be1b20a4a0dd