### PR TITLE
Add BCB integration hooks

### DIFF
--- a/includes/class-treasury-portal.php
+++ b/includes/class-treasury-portal.php
@@ -22,6 +22,12 @@ class Treasury_Tech_Portal {
         add_action('init', ['TTP_Rest', 'init']);
         add_action('init', ['TTP_Admin', 'init']);
 
+        add_filter('rt_portal_get_vendors', array($this, 'provide_vendors_to_bcb'));
+        add_filter('rt_portal_get_sectors', array($this, 'provide_sectors_to_bcb'));
+        add_filter('rt_portal_get_vendor_notes', array($this, 'provide_vendor_notes_to_bcb'));
+        add_action('rt_portal_new_lead', array($this, 'handle_bcb_lead'));
+        add_action('rt_portal_data_changed', array($this, 'notify_data_change'));
+
         add_shortcode('treasury_portal', array($this, 'shortcode_handler'));
     }
 
@@ -63,5 +69,122 @@ class Treasury_Tech_Portal {
         ob_start();
         include plugin_dir_path(__FILE__) . 'shortcode.php';
         return ob_get_clean();
+    }
+
+    public function provide_vendors_to_bcb($vendors = array()) {
+        $tools       = TTP_Data::get_all_tools();
+        $bcb_vendors = array();
+
+        foreach ($tools as $tool) {
+            $bcb_vendors[] = array(
+                'vendor_id'      => sanitize_title($tool['name']),
+                'name'           => $tool['name'],
+                'category'       => $this->map_category_to_bcb($tool['category']),
+                'target_segment' => $this->extract_target_segments($tool['target'] ?? ''),
+                'features'       => $tool['features'] ?? array(),
+                'integrations'   => $this->extract_integrations($tool),
+                'deployment'     => 'SaaS',
+                'pros'           => $this->extract_pros($tool),
+                'cons'           => $this->extract_cons($tool),
+                'sources'        => array(
+                    array(
+                        'doc' => 'portal',
+                        'loc' => 'treasury-portal',
+                    ),
+                ),
+            );
+        }
+
+        return $bcb_vendors;
+    }
+
+    private function map_category_to_bcb($portal_category) {
+        $mapping = array(
+            'CASH' => 'TMS',
+            'LITE' => 'TMS',
+            'TRMS' => 'TMS',
+        );
+
+        return $mapping[$portal_category] ?? 'TMS';
+    }
+
+    public function provide_sectors_to_bcb($sectors = array()) {
+        $tools       = TTP_Data::get_all_tools();
+        $bcb_sectors = array();
+
+        foreach ($tools as $tool) {
+            $sector                 = $this->map_category_to_bcb($tool['category']);
+            $bcb_sectors[$sector] = $sector;
+        }
+
+        return array_values($bcb_sectors);
+    }
+
+    public function provide_vendor_notes_to_bcb($notes = array()) {
+        $tools      = TTP_Data::get_all_tools();
+        $bcb_notes  = array();
+
+        foreach ($tools as $tool) {
+            $bcb_notes[sanitize_title($tool['name'])] = $tool['desc'] ?? '';
+        }
+
+        return $bcb_notes;
+    }
+
+    public function handle_bcb_lead($lead_data) {
+        $name    = sanitize_text_field($lead_data['name'] ?? '');
+        $email   = sanitize_email($lead_data['email'] ?? '');
+        $message = sanitize_textarea_field($lead_data['message'] ?? '');
+
+        if (empty($email)) {
+            return;
+        }
+
+        $subject = 'New BCB Lead';
+        $body    = "Name: {$name}\nEmail: {$email}\nMessage: {$message}";
+
+        wp_mail(get_option('admin_email'), $subject, $body);
+    }
+
+    public function notify_data_change() {
+        delete_transient(TTP_Data::CACHE_KEY);
+    }
+
+    private function extract_target_segments($target) {
+        if (empty($target)) {
+            return array();
+        }
+
+        $segments = preg_split('/[,\/]| and | & /', $target);
+        $segments = array_map('trim', $segments);
+        $segments = array_filter($segments, function ($seg) {
+            return !empty($seg);
+        });
+
+        return array_map('sanitize_text_field', $segments);
+    }
+
+    private function extract_integrations($tool) {
+        if (empty($tool['integrations']) || !is_array($tool['integrations'])) {
+            return array();
+        }
+
+        return array_map('sanitize_text_field', $tool['integrations']);
+    }
+
+    private function extract_pros($tool) {
+        if (empty($tool['pros']) || !is_array($tool['pros'])) {
+            return array();
+        }
+
+        return array_map('sanitize_text_field', $tool['pros']);
+    }
+
+    private function extract_cons($tool) {
+        if (empty($tool['cons']) || !is_array($tool['cons'])) {
+            return array();
+        }
+
+        return array_map('sanitize_text_field', $tool['cons']);
     }
 }


### PR DESCRIPTION
## Summary
- expose vendor, sector, and note data via new filters for Business Case Builder
- handle leads and cache refresh notices from BCB
- add helper methods to map categories, parse targets, and sanitize integration metadata

## Testing
- `scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a747623c288331b36db865e8f14258