### PR TITLE
Align Airbase option name

### DIFF
--- a/includes/class-ttp-admin.php
+++ b/includes/class-ttp-admin.php
@@ -49,12 +49,12 @@ class TTP_Admin {
 
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             check_admin_referer('ttp_airbase_settings');
-            update_option('ttp_airbase_api_key', sanitize_text_field($_POST['ttp_airbase_api_key'] ?? ''));
+            update_option(TTP_Airbase::OPTION_TOKEN, sanitize_text_field($_POST[TTP_Airbase::OPTION_TOKEN] ?? ''));
             update_option('ttp_airbase_base_url', esc_url_raw($_POST['ttp_airbase_base_url'] ?? ''));
             echo '<div class="notice notice-success is-dismissible"><p>' . esc_html__('Settings saved.', 'treasury-tech-portal') . '</p></div>';
         }
 
-        $api_key = get_option('ttp_airbase_api_key', '');
+        $api_token = get_option(TTP_Airbase::OPTION_TOKEN, '');
         $base_url = get_option('ttp_airbase_base_url', '');
         ?>
         <div class="wrap">
@@ -63,8 +63,8 @@ class TTP_Admin {
                 <?php wp_nonce_field('ttp_airbase_settings'); ?>
                 <table class="form-table" role="presentation">
                     <tr>
-                        <th scope="row"><label for="ttp_airbase_api_key"><?php esc_html_e('API Key', 'treasury-tech-portal'); ?></label></th>
-                        <td><input name="ttp_airbase_api_key" type="text" id="ttp_airbase_api_key" value="<?php echo esc_attr($api_key); ?>" class="regular-text" /></td>
+                        <th scope="row"><label for="<?php echo esc_attr(TTP_Airbase::OPTION_TOKEN); ?>"><?php esc_html_e('API Token', 'treasury-tech-portal'); ?></label></th>
+                        <td><input name="<?php echo esc_attr(TTP_Airbase::OPTION_TOKEN); ?>" type="text" id="<?php echo esc_attr(TTP_Airbase::OPTION_TOKEN); ?>" value="<?php echo esc_attr($api_token); ?>" class="regular-text" /></td>
                     </tr>
                     <tr>
                         <th scope="row"><label for="ttp_airbase_base_url"><?php esc_html_e('Base URL', 'treasury-tech-portal'); ?></label></th>

--- a/tests/test-ttp-airbase.php
+++ b/tests/test-ttp-airbase.php
@@ -17,7 +17,7 @@ class TTP_Airbase_Test extends TestCase {
     public function test_request_includes_authorization_header() {
         expect('get_option')
             ->once()
-            ->with('ttp_airbase_token')
+            ->with(TTP_Airbase::OPTION_TOKEN)
             ->andReturn('abc123');
 
         when('is_wp_error')->alias(function ($thing) {
@@ -49,7 +49,7 @@ class TTP_Airbase_Test extends TestCase {
     public function test_returns_wp_error_on_request_failure() {
         expect('get_option')
             ->once()
-            ->with('ttp_airbase_token')
+            ->with(TTP_Airbase::OPTION_TOKEN)
             ->andReturn('abc123');
 
         expect('wp_remote_get')
@@ -67,7 +67,7 @@ class TTP_Airbase_Test extends TestCase {
     public function test_returns_wp_error_when_token_missing() {
         expect('get_option')
             ->once()
-            ->with('ttp_airbase_token')
+            ->with(TTP_Airbase::OPTION_TOKEN)
             ->andReturn('');
 
         $result = TTP_Airbase::get_vendors();


### PR DESCRIPTION
## Summary
- save Airbase credentials under `ttp_airbase_token`
- reference Airbase token constant in tests

## Testing
- `scripts/test.sh`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68c17103f5ec8331991782a54844ab3c