### PR TITLE
Use configurable Airbase URL for product requests

### DIFF
--- a/includes/class-ttp-airbase.php
+++ b/includes/class-ttp-airbase.php
@@ -5,8 +5,9 @@ if (!defined('ABSPATH')) {
 }
 
 class TTP_Airbase {
-    const OPTION_TOKEN = 'ttp_airbase_token';
-    const API_URL      = 'https://api.airbase.com/v2/vendors';
+    const OPTION_TOKEN    = 'ttp_airbase_token';
+    const OPTION_BASE_URL = 'ttp_airbase_base_url';
+    const API_PATH        = '/v2/products';
 
     /**
      * Retrieve vendors from Airbase API.
@@ -19,6 +20,9 @@ class TTP_Airbase {
             return new WP_Error('missing_token', __('Airbase API token not configured.', 'treasury-tech-portal'));
         }
 
+        $base_url = get_option(self::OPTION_BASE_URL, 'https://api.airbase.com');
+        $url      = rtrim($base_url, '/') . self::API_PATH;
+
         $args = [
             'headers' => [
                 'Authorization' => 'Bearer ' . $token,
@@ -27,7 +31,7 @@ class TTP_Airbase {
             'timeout' => 20,
         ];
 
-        $response = wp_remote_get(self::API_URL, $args);
+        $response = wp_remote_get($url, $args);
         if (is_wp_error($response)) {
             return $response;
         }

--- a/includes/class-ttp-data.php
+++ b/includes/class-ttp-data.php
@@ -89,7 +89,7 @@ class TTP_Data {
             return;
         }
 
-        $vendors = isset($data['vendors']) ? $data['vendors'] : $data;
+        $vendors = isset($data['products']) ? $data['products'] : $data;
         self::save_vendors($vendors);
     }
 


### PR DESCRIPTION
## Summary
- Build Airbase request URL from the `ttp_airbase_base_url` option and target `/v2/products`
- Update vendor cache refresh to pull `products`
- Align tests with new products endpoint and response structure

## Testing
- `scripts/test.sh`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68c1a012c21883318992cfb91f0fcfcb