### PR TITLE
Ensure Airbase requests fall back to default URL

### DIFF
--- a/includes/class-ttp-airbase.php
+++ b/includes/class-ttp-airbase.php
@@ -20,8 +20,11 @@ class TTP_Airbase {
             return new WP_Error('missing_token', __('Airbase API token not configured.', 'treasury-tech-portal'));
         }
 
-        $base_url = get_option(self::OPTION_BASE_URL, 'https://api.airbase.com');
-        $url      = rtrim($base_url, '/') . self::API_PATH;
+        $base_url = get_option( self::OPTION_BASE_URL, 'https://api.airbase.com' );
+        if ( empty( $base_url ) ) {
+            $base_url = 'https://api.airbase.com';
+        }
+        $url      = rtrim( $base_url, '/' ) . self::API_PATH;
 
         $args = [
             'headers' => [


### PR DESCRIPTION
## Summary
- Default to `https://api.airbase.com` when the base URL option is empty

## Testing
- `scripts/test.sh`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68c1a1db570c83318f870bd63bf53395