### PR TITLE
Use api.airbase.io and update tests

### DIFF
--- a/includes/class-ttp-airbase.php
+++ b/includes/class-ttp-airbase.php
@@ -20,9 +20,9 @@ class TTP_Airbase {
             return new WP_Error('missing_token', __('Airbase API token not configured.', 'treasury-tech-portal'));
         }
 
-        $base_url = get_option( self::OPTION_BASE_URL, 'https://api.airbase.com' );
+        $base_url = get_option( self::OPTION_BASE_URL, 'https://api.airbase.io' );
         if ( empty( $base_url ) ) {
-            $base_url = 'https://api.airbase.com';
+            $base_url = 'https://api.airbase.io';
         }
         $url      = rtrim( $base_url, '/' ) . self::API_PATH;
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,6 @@
 <?php
 require __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/../vendor/antecedent/patchwork/Patchwork.php';
 
 if (!class_exists('WP_Error')) {
     class WP_Error {

--- a/tests/test-ttp-airbase.php
+++ b/tests/test-ttp-airbase.php
@@ -30,7 +30,7 @@ class TTP_Airbase_Test extends TestCase {
         });
 
         $self         = $this;
-        $expected_url = 'https://api.airbase.com' . TTP_Airbase::API_PATH;
+        $expected_url = 'https://api.airbase.io' . TTP_Airbase::API_PATH;
         expect('wp_remote_get')->once()->andReturnUsing(function ($url, $args) use ($self, $expected_url) {
             $self->assertSame($expected_url, $url);
             $self->assertArrayHasKey('headers', $args);


### PR DESCRIPTION
## Summary
- default Airbase endpoint now points to https://api.airbase.io
- adjust unit test expectation for new Airbase endpoint
- load Patchwork during test bootstrap so vendor tests run cleanly

## Testing
- `scripts/test.sh`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68c1c581eec483319694b5ccc230b0ae