### PR TITLE
Parametrize Airbase endpoint

### DIFF
--- a/AIRBASE_API.md
+++ b/AIRBASE_API.md
@@ -7,6 +7,11 @@ The following is a condensed reference for developers working with the API.
 - **Base ID**: `appJdxdz3310aJ3Fd`
 - **Products Table ID**: `tblOJ6yL9Jw5ZTdRc`
 
+### Plugin Configuration Options
+- `ttp_airbase_base_url` – Base API URL. Default: `https://api.airtable.com/v0`
+- `ttp_airbase_base_id` – Airtable base identifier. Default: `appJdxdz3310aJ3Fd`
+- `ttp_airbase_api_path` – Table/endpoint path. Default: `tblOJ6yL9Jw5ZTdRc`
+
 ## Authentication
 All requests require a bearer token:
 
@@ -44,6 +49,8 @@ Retrieve records from the Products table. Only non-empty fields are returned.
 curl "https://api.airtable.com/v0/appJdxdz3310aJ3Fd/Products?maxRecords=3&view=Grid%20view" \
   -H "Authorization: Bearer YOUR_SECRET_API_TOKEN"
 ```
+
+Responses include a top-level `records` array containing matching rows.
 
 Common query parameters:
 - `fields[]`: restrict returned fields

--- a/includes/class-ttp-airbase.php
+++ b/includes/class-ttp-airbase.php
@@ -5,9 +5,14 @@ if (!defined('ABSPATH')) {
 }
 
 class TTP_Airbase {
-    const OPTION_TOKEN    = 'ttp_airbase_token';
-    const OPTION_BASE_URL = 'ttp_airbase_base_url';
-    const API_PATH        = '/v2/products';
+    const OPTION_TOKEN     = 'ttp_airbase_token';
+    const OPTION_BASE_URL  = 'ttp_airbase_base_url';
+    const OPTION_BASE_ID   = 'ttp_airbase_base_id';
+    const OPTION_API_PATH  = 'ttp_airbase_api_path';
+
+    const DEFAULT_BASE_URL = 'https://api.airtable.com/v0';
+    const DEFAULT_BASE_ID  = 'appJdxdz3310aJ3Fd';
+    const DEFAULT_API_PATH = 'tblOJ6yL9Jw5ZTdRc';
 
     /**
      * Retrieve vendors from Airbase API.
@@ -20,11 +25,22 @@ class TTP_Airbase {
             return new WP_Error('missing_token', __('Airbase API token not configured.', 'treasury-tech-portal'));
         }
 
-        $base_url = get_option( self::OPTION_BASE_URL, 'https://api.airbase.io' );
-        if ( empty( $base_url ) ) {
-            $base_url = 'https://api.airbase.io';
+        $base_url = get_option(self::OPTION_BASE_URL, self::DEFAULT_BASE_URL);
+        if (empty($base_url)) {
+            $base_url = self::DEFAULT_BASE_URL;
         }
-        $url      = rtrim( $base_url, '/' ) . self::API_PATH;
+
+        $base_id = get_option(self::OPTION_BASE_ID, self::DEFAULT_BASE_ID);
+        if (empty($base_id)) {
+            $base_id = self::DEFAULT_BASE_ID;
+        }
+
+        $api_path = get_option(self::OPTION_API_PATH, self::DEFAULT_API_PATH);
+        if (empty($api_path)) {
+            $api_path = self::DEFAULT_API_PATH;
+        }
+
+        $url = rtrim($base_url, '/') . '/' . trim($base_id, '/') . '/' . ltrim($api_path, '/');
 
         $args = [
             'headers' => [

--- a/tests/test-ttp-airbase-connection.php
+++ b/tests/test-ttp-airbase-connection.php
@@ -77,6 +77,16 @@ class TTP_Airbase_Connection_Test extends TestCase {
             update_option( TTP_Airbase::OPTION_BASE_URL, $base_url );
         }
 
+        $base_id = getenv( 'AIRBASE_BASE_ID' );
+        if ( ! empty( $base_id ) ) {
+            update_option( TTP_Airbase::OPTION_BASE_ID, $base_id );
+        }
+
+        $api_path = getenv( 'AIRBASE_API_PATH' );
+        if ( ! empty( $api_path ) ) {
+            update_option( TTP_Airbase::OPTION_API_PATH, $api_path );
+        }
+
         $vendors = TTP_Airbase::get_vendors();
 
         if ( is_wp_error( $vendors ) ) {
@@ -84,6 +94,6 @@ class TTP_Airbase_Connection_Test extends TestCase {
         }
 
         $this->assertIsArray( $vendors );
-        $this->assertArrayHasKey( 'products', $vendors );
+        $this->assertArrayHasKey( 'records', $vendors );
     }
 }


### PR DESCRIPTION
## Summary
- add configurable base ID and endpoint path for the Airbase API
- build request URLs from base URL, base ID and path
- document new configuration options and update tests for `records` responses

## Testing
- `./scripts/test.sh`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68c1e77b3de083319682f36944923756