### PR TITLE
Parametrize Airbase endpoint: fix vendor cache for records response

### DIFF
--- a/includes/class-ttp-data.php
+++ b/includes/class-ttp-data.php
@@ -89,7 +89,14 @@ class TTP_Data {
             return;
         }
 
-        $vendors = isset($data['products']) ? $data['products'] : $data;
+        if (isset($data['records'])) {
+            $vendors = $data['records'];
+        } elseif (isset($data['products'])) {
+            $vendors = $data['products'];
+        } else {
+            $vendors = $data;
+        }
+
         self::save_vendors($vendors);
     }
 


### PR DESCRIPTION
## Summary
- handle `records` key when refreshing cached vendor data

## Testing
- `./scripts/test.sh`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68c1e959ebc48331a1e2189e678b8a08