### PR TITLE
Expose Airbase base ID and API path settings

### DIFF
--- a/AIRBASE_API.md
+++ b/AIRBASE_API.md
@@ -8,9 +8,12 @@ The following is a condensed reference for developers working with the API.
 - **Products Table ID**: `tblOJ6yL9Jw5ZTdRc`
 
 ### Plugin Configuration Options
+- `ttp_airbase_token` – API token used for authentication.
 - `ttp_airbase_base_url` – Base API URL. Default: `https://api.airtable.com/v0`
 - `ttp_airbase_base_id` – Airtable base identifier. Default: `appJdxdz3310aJ3Fd`
 - `ttp_airbase_api_path` – Table/endpoint path. Default: `tblOJ6yL9Jw5ZTdRc`
+
+These options are configurable from the **Airbase Settings** page in the WordPress admin.
 
 ## Authentication
 All requests require a bearer token:

--- a/API.md
+++ b/API.md
@@ -88,6 +88,8 @@ GET /wp-json/ttp/v1/vendors
 Array of vendor objects retrieved from Airbase.
 
 See [AIRBASE_API.md](AIRBASE_API.md) for detailed vendor API documentation.
+The integration relies on four WordPress options to configure API access:
+`ttp_airbase_token`, `ttp_airbase_base_url`, `ttp_airbase_base_id`, and `ttp_airbase_api_path`.
 
 #### Example Request
 ```

--- a/includes/class-ttp-admin.php
+++ b/includes/class-ttp-admin.php
@@ -52,6 +52,8 @@ class TTP_Admin {
             check_admin_referer('ttp_airbase_settings');
             update_option(TTP_Airbase::OPTION_TOKEN, sanitize_text_field($_POST[TTP_Airbase::OPTION_TOKEN] ?? ''));
             update_option(TTP_Airbase::OPTION_BASE_URL, esc_url_raw($_POST[TTP_Airbase::OPTION_BASE_URL] ?? ''));
+            update_option(TTP_Airbase::OPTION_BASE_ID, sanitize_text_field($_POST[TTP_Airbase::OPTION_BASE_ID] ?? ''));
+            update_option(TTP_Airbase::OPTION_API_PATH, sanitize_text_field($_POST[TTP_Airbase::OPTION_API_PATH] ?? ''));
             echo '<div class="notice notice-success is-dismissible"><p>' . esc_html__('Settings saved.', 'treasury-tech-portal') . '</p></div>';
         }
 
@@ -63,7 +65,9 @@ class TTP_Admin {
         }
 
         $api_token = get_option(TTP_Airbase::OPTION_TOKEN, '');
-        $base_url = get_option(TTP_Airbase::OPTION_BASE_URL, '');
+        $base_url  = get_option(TTP_Airbase::OPTION_BASE_URL, '');
+        $base_id   = get_option(TTP_Airbase::OPTION_BASE_ID, '');
+        $api_path  = get_option(TTP_Airbase::OPTION_API_PATH, '');
         ?>
         <div class="wrap">
             <h1><?php esc_html_e('Airbase Settings', 'treasury-tech-portal'); ?></h1>
@@ -77,6 +81,14 @@ class TTP_Admin {
                     <tr>
                         <th scope="row"><label for="<?php echo esc_attr(TTP_Airbase::OPTION_BASE_URL); ?>"><?php esc_html_e('Base URL', 'treasury-tech-portal'); ?></label></th>
                         <td><input name="<?php echo esc_attr(TTP_Airbase::OPTION_BASE_URL); ?>" type="text" id="<?php echo esc_attr(TTP_Airbase::OPTION_BASE_URL); ?>" value="<?php echo esc_attr($base_url); ?>" class="regular-text" /></td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><label for="<?php echo esc_attr(TTP_Airbase::OPTION_BASE_ID); ?>"><?php esc_html_e('Base ID', 'treasury-tech-portal'); ?></label></th>
+                        <td><input name="<?php echo esc_attr(TTP_Airbase::OPTION_BASE_ID); ?>" type="text" id="<?php echo esc_attr(TTP_Airbase::OPTION_BASE_ID); ?>" value="<?php echo esc_attr($base_id); ?>" class="regular-text" /></td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><label for="<?php echo esc_attr(TTP_Airbase::OPTION_API_PATH); ?>"><?php esc_html_e('API Path', 'treasury-tech-portal'); ?></label></th>
+                        <td><input name="<?php echo esc_attr(TTP_Airbase::OPTION_API_PATH); ?>" type="text" id="<?php echo esc_attr(TTP_Airbase::OPTION_API_PATH); ?>" value="<?php echo esc_attr($api_path); ?>" class="regular-text" /></td>
                     </tr>
                 </table>
                 <?php submit_button(); ?>

--- a/readme.txt
+++ b/readme.txt
@@ -20,6 +20,9 @@ Add the portal to any page or post using the shortcode:
 
 [treasury_portal]
 
+To pull vendor data from Airbase, configure the API token, base URL, base ID,
+and API path under **Treasury Tools → Airbase Settings** in the WordPress admin.
+
 == Installation ==
 
 This plugin is automatically deployed from GitHub to your WordPress site through your hosting provider's integration.


### PR DESCRIPTION
## Summary
- add Base ID and API Path fields to Airbase settings page
- document new Airbase options and admin configuration

## Testing
- `scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c20006f844833192ff61dbdc36e5d1