### PR TITLE
Add Airbase pagination and field filtering

### DIFF
--- a/includes/class-ttp-airbase.php
+++ b/includes/class-ttp-airbase.php
@@ -17,68 +17,98 @@ class TTP_Airbase {
     /**
      * Retrieve vendors from Airbase API.
      *
-     * @return array|WP_Error Parsed vendor data or WP_Error on failure.
+     * @param array $fields Optional list of field IDs or names to request.
+     *
+     * @return array|WP_Error Array of vendor records or WP_Error on failure.
      */
-    public static function get_vendors() {
-        $token = get_option(self::OPTION_TOKEN);
-        if (empty($token)) {
-            return new WP_Error('missing_token', __('Airbase API token not configured.', 'treasury-tech-portal'));
+    public static function get_vendors( $fields = array() ) {
+        $token = get_option( self::OPTION_TOKEN );
+        if ( empty( $token ) ) {
+            return new WP_Error( 'missing_token', __( 'Airbase API token not configured.', 'treasury-tech-portal' ) );
         }
 
-        $base_url = get_option(self::OPTION_BASE_URL, self::DEFAULT_BASE_URL);
-        if (empty($base_url)) {
+        $base_url = get_option( self::OPTION_BASE_URL, self::DEFAULT_BASE_URL );
+        if ( empty( $base_url ) ) {
             $base_url = self::DEFAULT_BASE_URL;
         }
 
-        $parts = wp_parse_url($base_url);
-        if (!is_array($parts) || empty($parts['scheme']) || empty($parts['host'])) {
-            return new WP_Error('invalid_base_url', __('Invalid Airbase base URL.', 'treasury-tech-portal'));
+        $parts = wp_parse_url( $base_url );
+        if ( ! is_array( $parts ) || empty( $parts['scheme'] ) || empty( $parts['host'] ) ) {
+            return new WP_Error( 'invalid_base_url', __( 'Invalid Airbase base URL.', 'treasury-tech-portal' ) );
         }
 
-        if (empty($parts['path']) || '/' === $parts['path']) {
-            $base_url = rtrim($base_url, '/') . '/v0';
+        if ( empty( $parts['path'] ) || '/' === $parts['path'] ) {
+            $base_url = rtrim( $base_url, '/' ) . '/v0';
         }
 
-        $base_id = get_option(self::OPTION_BASE_ID, self::DEFAULT_BASE_ID);
-        if (empty($base_id)) {
+        $base_id = get_option( self::OPTION_BASE_ID, self::DEFAULT_BASE_ID );
+        if ( empty( $base_id ) ) {
             $base_id = self::DEFAULT_BASE_ID;
         }
 
-        $api_path = get_option(self::OPTION_API_PATH, self::DEFAULT_API_PATH);
-        if (empty($api_path)) {
+        $api_path = get_option( self::OPTION_API_PATH, self::DEFAULT_API_PATH );
+        if ( empty( $api_path ) ) {
             $api_path = self::DEFAULT_API_PATH;
         }
 
-        $url = rtrim($base_url, '/') . '/' . trim($base_id, '/') . '/' . ltrim($api_path, '/');
+        $base_endpoint = rtrim( $base_url, '/' ) . '/' . trim( $base_id, '/' ) . '/' . ltrim( $api_path, '/' );
 
-        if (!wp_http_validate_url($url)) {
-            return new WP_Error('invalid_api_url', __('Invalid Airbase API URL.', 'treasury-tech-portal'));
+        if ( ! wp_http_validate_url( $base_endpoint ) ) {
+            return new WP_Error( 'invalid_api_url', __( 'Invalid Airbase API URL.', 'treasury-tech-portal' ) );
         }
 
-        $args = [
-            'headers' => [
+        $args = array(
+            'headers' => array(
                 'Authorization' => 'Bearer ' . $token,
                 'Accept'        => 'application/json',
-            ],
+            ),
             'timeout' => 20,
-        ];
+        );
 
-        $response = wp_remote_get($url, $args);
-        if (is_wp_error($response)) {
-            return $response;
-        }
+        $records = array();
+        $offset  = '';
 
-        $code = wp_remote_retrieve_response_code($response);
-        if (200 !== $code) {
-            return new WP_Error('api_error', sprintf('Airbase API returned status %d', $code));
-        }
+        do {
+            $url = $base_endpoint;
+            $query = array();
 
-        $body = wp_remote_retrieve_body($response);
-        $data = json_decode($body, true);
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            return new WP_Error('invalid_json', __('Unable to parse Airbase API response.', 'treasury-tech-portal'));
-        }
+            if ( $offset ) {
+                $query[] = 'offset=' . rawurlencode( $offset );
+            }
 
-        return $data;
+            if ( ! empty( $fields ) ) {
+                foreach ( $fields as $field ) {
+                    $query[] = 'fields[]=' . rawurlencode( $field );
+                }
+            }
+
+            if ( ! empty( $query ) ) {
+                $url .= '?' . implode( '&', $query );
+            }
+
+            $response = wp_remote_get( $url, $args );
+            if ( is_wp_error( $response ) ) {
+                return $response;
+            }
+
+            $code = wp_remote_retrieve_response_code( $response );
+            if ( 200 !== $code ) {
+                return new WP_Error( 'api_error', sprintf( 'Airbase API returned status %d', $code ) );
+            }
+
+            $body = wp_remote_retrieve_body( $response );
+            $data = json_decode( $body, true );
+            if ( JSON_ERROR_NONE !== json_last_error() ) {
+                return new WP_Error( 'invalid_json', __( 'Unable to parse Airbase API response.', 'treasury-tech-portal' ) );
+            }
+
+            if ( isset( $data['records'] ) && is_array( $data['records'] ) ) {
+                $records = array_merge( $records, $data['records'] );
+            }
+
+            $offset = isset( $data['offset'] ) ? $data['offset'] : '';
+        } while ( $offset );
+
+        return $records;
     }
 }

--- a/tests/test-ttp-airbase-connection.php
+++ b/tests/test-ttp-airbase-connection.php
@@ -106,6 +106,8 @@ class TTP_Airbase_Connection_Test extends TestCase {
         }
 
         $this->assertIsArray( $vendors );
-        $this->assertArrayHasKey( 'records', $vendors );
+        if ( ! empty( $vendors ) ) {
+            $this->assertIsArray( $vendors[0] );
+        }
     }
 }

--- a/tests/test-ttp-airbase.php
+++ b/tests/test-ttp-airbase.php
@@ -58,7 +58,7 @@ class TTP_Airbase_Test extends TestCase {
 
         $data = TTP_Airbase::get_vendors();
         $this->assertIsArray($data);
-        $this->assertArrayHasKey('records', $data);
+        $this->assertCount(0, $data);
     }
 
     public function test_returns_wp_error_on_request_failure() {
@@ -124,5 +124,101 @@ class TTP_Airbase_Test extends TestCase {
 
         $data = TTP_Airbase::get_vendors();
         $this->assertIsArray($data);
+    }
+
+    public function test_paginates_until_all_records_retrieved() {
+        when('get_option')->alias(function ($option, $default = false) {
+            switch ($option) {
+                case TTP_Airbase::OPTION_TOKEN:
+                    return 'abc123';
+                case TTP_Airbase::OPTION_BASE_URL:
+                    return TTP_Airbase::DEFAULT_BASE_URL;
+                case TTP_Airbase::OPTION_BASE_ID:
+                    return 'base123';
+                case TTP_Airbase::OPTION_API_PATH:
+                    return 'tblXYZ';
+                default:
+                    return $default;
+            }
+        });
+
+        when('is_wp_error')->alias(function ($thing) {
+            return $thing instanceof WP_Error;
+        });
+        when('wp_remote_retrieve_response_code')->alias(function ($response) {
+            return $response['response']['code'];
+        });
+        when('wp_remote_retrieve_body')->alias(function ($response) {
+            return $response['body'];
+        });
+
+        $self       = $this;
+        $base_url   = TTP_Airbase::DEFAULT_BASE_URL . '/base123/tblXYZ';
+        $call_count = 0;
+        expect('wp_remote_get')->twice()->andReturnUsing(function ($url) use ($self, $base_url, &$call_count) {
+            $call_count++;
+            if (1 === $call_count) {
+                $self->assertSame($base_url, $url);
+                return [
+                    'response' => ['code' => 200],
+                    'body'     => json_encode([
+                        'records' => [['id' => 'rec1']],
+                        'offset'  => 'abc',
+                    ]),
+                ];
+            }
+
+            $self->assertSame($base_url . '?offset=abc', $url);
+            return [
+                'response' => ['code' => 200],
+                'body'     => json_encode([
+                    'records' => [['id' => 'rec2']],
+                ]),
+            ];
+        });
+
+        $records = TTP_Airbase::get_vendors();
+        $this->assertIsArray($records);
+        $this->assertCount(2, $records);
+        $this->assertSame('rec2', $records[1]['id']);
+    }
+
+    public function test_adds_fields_query_parameters() {
+        when('get_option')->alias(function ($option, $default = false) {
+            switch ($option) {
+                case TTP_Airbase::OPTION_TOKEN:
+                    return 'abc123';
+                case TTP_Airbase::OPTION_BASE_URL:
+                    return TTP_Airbase::DEFAULT_BASE_URL;
+                case TTP_Airbase::OPTION_BASE_ID:
+                    return 'base123';
+                case TTP_Airbase::OPTION_API_PATH:
+                    return 'tblXYZ';
+                default:
+                    return $default;
+            }
+        });
+
+        when('is_wp_error')->alias(function ($thing) {
+            return $thing instanceof WP_Error;
+        });
+        when('wp_remote_retrieve_response_code')->alias(function ($response) {
+            return $response['response']['code'];
+        });
+        when('wp_remote_retrieve_body')->alias(function ($response) {
+            return $response['body'];
+        });
+
+        $expected_url = TTP_Airbase::DEFAULT_BASE_URL . '/base123/tblXYZ?fields[]=Name&fields[]=Email';
+        expect('wp_remote_get')->once()->andReturnUsing(function ($url) use ($expected_url) {
+            $this->assertSame($expected_url, $url);
+            return [
+                'response' => ['code' => 200],
+                'body'     => json_encode(['records' => []]),
+            ];
+        });
+
+        $records = TTP_Airbase::get_vendors(['Name', 'Email']);
+        $this->assertIsArray($records);
     }
 }


### PR DESCRIPTION
## Summary
- paginate Airbase vendor requests until no offset remains
- allow requesting specific fields via `fields[]` query parameters
- expand tests to cover pagination and field filtering

## Testing
- `scripts/test.sh`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68c2069c4080833186a6773cbbb01c1c