### PR TITLE
Normalize vendor fields from Airbase

### DIFF
--- a/includes/class-ttp-data.php
+++ b/includes/class-ttp-data.php
@@ -88,7 +88,31 @@ class TTP_Data {
         if (is_wp_error($data)) {
             return;
         }
-        $vendors = self::normalize_vendor_response($data);
+
+        $records = self::normalize_vendor_response($data);
+
+        $vendors = array();
+        foreach ($records as $record) {
+            $fields = isset($record['fields']) && is_array($record['fields']) ? $record['fields'] : $record;
+
+            $vendors[] = array(
+                'name'          => $fields['Product Name'] ?? '',
+                'vendor'        => $fields['Linked Vendor'] ?? '',
+                'website'       => $fields['Product Website'] ?? '',
+                'status'        => $fields['Status'] ?? '',
+                'hosted_type'   => $fields['Hosted Type'] ?? array(),
+                'domain'        => $fields['Domain'] ?? array(),
+                'regions'       => $fields['Regions'] ?? array(),
+                'sub_categories'=> $fields['Sub Categories'] ?? array(),
+                'parent_category' => $fields['Parent Category'] ?? '',
+                'capabilities'  => $fields['Capabilities'] ?? array(),
+                'logo_url'      => $fields['Logo URL'] ?? '',
+                'hq_location'   => $fields['HQ Location'] ?? '',
+                'founded_year'  => $fields['Founded Year'] ?? '',
+                'founders'      => $fields['Founders'] ?? '',
+            );
+        }
+
         self::save_vendors($vendors);
     }
 

--- a/tests/test-ttp-data.php
+++ b/tests/test-ttp-data.php
@@ -18,9 +18,20 @@ class TTP_Data_Test extends TestCase {
         \Brain\Monkey\tearDown();
     }
 
-    public function test_refresh_vendor_cache_handles_records_response() {
-        \Patchwork\replace('TTP_Airbase::get_vendors', function () {
-            return ['records' => [ ['id' => 1, 'name' => 'Vendor R'] ]];
+    public function test_refresh_vendor_cache_maps_fields() {
+        $record = [
+            'id' => 'rec1',
+            'fields' => [
+                'Product Name'   => 'Sample Product',
+                'Linked Vendor'  => 'Acme Corp',
+                'Product Website'=> 'https://example.com',
+                'Status'         => 'Active',
+                'Hosted Type'    => ['Cloud'],
+            ],
+        ];
+
+        \Patchwork\replace('TTP_Airbase::get_vendors', function () use ($record) {
+            return ['records' => [ $record ]];
         });
 
         $captured = null;
@@ -29,34 +40,26 @@ class TTP_Data_Test extends TestCase {
         });
 
         TTP_Data::refresh_vendor_cache();
-        $this->assertSame([ ['id' => 1, 'name' => 'Vendor R'] ], $captured);
-    }
 
-    public function test_refresh_vendor_cache_handles_products_response() {
-        \Patchwork\replace('TTP_Airbase::get_vendors', function () {
-            return ['products' => [ ['id' => 2, 'name' => 'Vendor P'] ]];
-        });
+        $expected = [
+            [
+                'name'        => 'Sample Product',
+                'vendor'      => 'Acme Corp',
+                'website'     => 'https://example.com',
+                'status'      => 'Active',
+                'hosted_type' => ['Cloud'],
+                'domain'      => [],
+                'regions'     => [],
+                'sub_categories' => [],
+                'parent_category' => '',
+                'capabilities' => [],
+                'logo_url'    => '',
+                'hq_location' => '',
+                'founded_year'=> '',
+                'founders'    => '',
+            ],
+        ];
 
-        $captured = null;
-        \Patchwork\replace('TTP_Data::save_vendors', function ($vendors) use (&$captured) {
-            $captured = $vendors;
-        });
-
-        TTP_Data::refresh_vendor_cache();
-        $this->assertSame([ ['id' => 2, 'name' => 'Vendor P'] ], $captured);
-    }
-
-    public function test_refresh_vendor_cache_handles_vendors_response() {
-        \Patchwork\replace('TTP_Airbase::get_vendors', function () {
-            return ['vendors' => [ ['id' => 3, 'name' => 'Vendor V'] ]];
-        });
-
-        $captured = null;
-        \Patchwork\replace('TTP_Data::save_vendors', function ($vendors) use (&$captured) {
-            $captured = $vendors;
-        });
-
-        TTP_Data::refresh_vendor_cache();
-        $this->assertSame([ ['id' => 3, 'name' => 'Vendor V'] ], $captured);
+        $this->assertSame($expected, $captured);
     }
 }


### PR DESCRIPTION
## Summary
- Map Airtable vendor fields to normalized objects in `refresh_vendor_cache`
- Cache only normalized vendor data in options and transients
- Test vendor field mapping from Airbase records

## Testing
- `vendor/bin/phpunit`
- `scripts/test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c207ea0e088331bd6f2d113fed831e