### PR TITLE
Map additional Airbase vendor fields

### DIFF
--- a/includes/class-ttp-data.php
+++ b/includes/class-ttp-data.php
@@ -96,20 +96,21 @@ class TTP_Data {
             $fields = isset($record['fields']) && is_array($record['fields']) ? $record['fields'] : $record;
 
             $vendors[] = array(
-                'name'          => $fields['Product Name'] ?? '',
-                'vendor'        => $fields['Linked Vendor'] ?? '',
-                'website'       => $fields['Product Website'] ?? '',
-                'status'        => $fields['Status'] ?? '',
-                'hosted_type'   => $fields['Hosted Type'] ?? array(),
-                'domain'        => $fields['Domain'] ?? array(),
-                'regions'       => $fields['Regions'] ?? array(),
-                'sub_categories'=> $fields['Sub Categories'] ?? array(),
+                'name'            => $fields['Product Name'] ?? '',
+                'vendor'          => $fields['Linked Vendor'] ?? '',
+                'website'         => self::normalize_url($fields['Product Website'] ?? ''),
+                'video_url'       => self::normalize_url($fields['Product Video'] ?? ''),
+                'status'          => $fields['Status'] ?? '',
+                'hosted_type'     => $fields['Hosted Type'] ?? array(),
+                'domain'          => $fields['Domain'] ?? array(),
+                'regions'         => $fields['Regions'] ?? array(),
+                'sub_categories'  => $fields['Sub Categories'] ?? array(),
                 'parent_category' => $fields['Parent Category'] ?? '',
-                'capabilities'  => $fields['Capabilities'] ?? array(),
-                'logo_url'      => $fields['Logo URL'] ?? '',
-                'hq_location'   => $fields['HQ Location'] ?? '',
-                'founded_year'  => $fields['Founded Year'] ?? '',
-                'founders'      => $fields['Founders'] ?? '',
+                'capabilities'    => $fields['Capabilities'] ?? array(),
+                'logo_url'        => self::normalize_url($fields['Logo URL'] ?? ''),
+                'hq_location'     => $fields['HQ Location'] ?? '',
+                'founded_year'    => $fields['Founded Year'] ?? '',
+                'founders'        => $fields['Founders'] ?? '',
             );
         }
 
@@ -140,6 +141,36 @@ class TTP_Data {
         }
 
         return $data;
+    }
+
+    /**
+     * Normalize and sanitize a URL value.
+     *
+     * Ensures a scheme is present and validates via WordPress utilities when
+     * available. Returns an empty string for invalid URLs.
+     *
+     * @param string $url Raw URL value.
+     * @return string Normalized URL or empty string if invalid.
+     */
+    private static function normalize_url($url) {
+        $url = trim((string) $url);
+        if ($url === '') {
+            return '';
+        }
+
+        if (strpos($url, '://') === false) {
+            $url = 'https://' . ltrim($url, '/');
+        }
+
+        if (function_exists('esc_url_raw')) {
+            $url = esc_url_raw($url);
+        }
+
+        if (function_exists('wp_http_validate_url') && !wp_http_validate_url($url)) {
+            return '';
+        }
+
+        return $url;
     }
 
 /**

--- a/tests/test-ttp-data.php
+++ b/tests/test-ttp-data.php
@@ -22,11 +22,13 @@ class TTP_Data_Test extends TestCase {
         $record = [
             'id' => 'rec1',
             'fields' => [
-                'Product Name'   => 'Sample Product',
-                'Linked Vendor'  => 'Acme Corp',
-                'Product Website'=> 'https://example.com',
-                'Status'         => 'Active',
-                'Hosted Type'    => ['Cloud'],
+                'Product Name'    => 'Sample Product',
+                'Linked Vendor'   => 'Acme Corp',
+                'Product Website' => 'example.com',
+                'Product Video'   => 'example.com/video',
+                'Logo URL'        => 'example.com/logo.png',
+                'Status'          => 'Active',
+                'Hosted Type'     => ['Cloud'],
             ],
         ];
 
@@ -43,20 +45,21 @@ class TTP_Data_Test extends TestCase {
 
         $expected = [
             [
-                'name'        => 'Sample Product',
-                'vendor'      => 'Acme Corp',
-                'website'     => 'https://example.com',
-                'status'      => 'Active',
-                'hosted_type' => ['Cloud'],
-                'domain'      => [],
-                'regions'     => [],
-                'sub_categories' => [],
+                'name'            => 'Sample Product',
+                'vendor'          => 'Acme Corp',
+                'website'         => 'https://example.com',
+                'video_url'       => 'https://example.com/video',
+                'status'          => 'Active',
+                'hosted_type'     => ['Cloud'],
+                'domain'          => [],
+                'regions'         => [],
+                'sub_categories'  => [],
                 'parent_category' => '',
-                'capabilities' => [],
-                'logo_url'    => '',
-                'hq_location' => '',
-                'founded_year'=> '',
-                'founders'    => '',
+                'capabilities'    => [],
+                'logo_url'        => 'https://example.com/logo.png',
+                'hq_location'     => '',
+                'founded_year'    => '',
+                'founders'        => '',
             ],
         ];
 


### PR DESCRIPTION
## Summary
- map Airbase `Product Video`, `Product Website`, and `Logo URL` to normalized vendor metadata
- normalize URLs via helper and update tests for saved metadata

## Testing
- `vendor/bin/phpunit`
- `scripts/test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c20dd79ba8833180adf0924b9232fe