### PR TITLE
Switch frontend to Airbase vendor endpoint

### DIFF
--- a/assets/js/treasury-portal.js
+++ b/assets/js/treasury-portal.js
@@ -308,7 +308,20 @@ document.addEventListener('DOMContentLoaded', async () => {
                 try {
                     const response = await fetch(TTP_DATA.rest_url);
                     const data = await response.json();
-                    this.TREASURY_TOOLS = data;
+                    this.TREASURY_TOOLS = (Array.isArray(data) ? data : []).map(vendor => {
+                        const categoryField = vendor.parent_category || vendor.category || '';
+                        const category = Array.isArray(categoryField) ? categoryField[0] : categoryField;
+                        return {
+                            name: vendor.name || '',
+                            desc: vendor.status || '',
+                            category: (category || '').toUpperCase(),
+                            videoUrl: vendor.video_url || '',
+                            websiteUrl: vendor.website || '',
+                            logoUrl: vendor.logo_url || '',
+                            features: vendor.capabilities || [],
+                            target: ''
+                        };
+                    });
                     this.assignTags();
                     this.updateCounts();
                     this.populateCategoryTags();

--- a/includes/class-treasury-portal.php
+++ b/includes/class-treasury-portal.php
@@ -64,7 +64,7 @@ class Treasury_Tech_Portal {
             'treasury-tech-portal-js',
             'TTP_DATA',
             [
-                'rest_url'  => esc_url_raw(rest_url('ttp/v1/tools')),
+                'rest_url'  => esc_url_raw(rest_url('ttp/v1/vendors')),
                 'plugin_url' => esc_url_raw($plugin_url)
             ]
         );

--- a/includes/class-ttp-rest.php
+++ b/includes/class-ttp-rest.php
@@ -12,7 +12,7 @@ class TTP_Rest {
     public static function register_routes() {
         register_rest_route('ttp/v1', '/tools', [
             'methods'  => 'GET',
-            'callback' => [__CLASS__, 'get_tools'],
+            'callback' => [__CLASS__, 'get_vendors'],
             'permission_callback' => '__return_true'
         ]);
 
@@ -26,18 +26,5 @@ class TTP_Rest {
     public static function get_vendors($request) {
         $vendors = TTP_Data::get_all_vendors();
         return rest_ensure_response($vendors);
-    }
-
-    public static function get_tools($request) {
-        $args = [
-            'category'  => sanitize_text_field($request->get_param('category')),
-            'search'    => sanitize_text_field($request->get_param('search')),
-            'has_video' => $request->get_param('has_video') ? true : false,
-            'per_page'  => absint($request->get_param('per_page')),
-            'page'      => absint($request->get_param('page')),
-        ];
-        $tools = TTP_Data::get_tools($args);
-
-        return rest_ensure_response($tools);
     }
 }


### PR DESCRIPTION
## Summary
- Repoint `/tools` REST route to serve Airbase-backed vendor data while retaining `/vendors` endpoint
- Update localized script URL to `/wp-json/ttp/v1/vendors`
- Parse vendor records on load and map fields to existing UI properties

## Testing
- `scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c20e0f9f788331bfd1bbd5148ce0c4