### PR TITLE
Replace tool management with vendor list

### DIFF
--- a/includes/class-ttp-admin.php
+++ b/includes/class-ttp-admin.php
@@ -7,16 +7,14 @@ if (!defined('ABSPATH')) {
 class TTP_Admin {
     public static function init() {
         add_action('admin_menu', [__CLASS__, 'register_menu']);
-        add_action('admin_post_ttp_save_tool', [__CLASS__, 'save_tool']);
-        add_action('admin_post_ttp_delete_tool', [__CLASS__, 'delete_tool']);
         add_action('admin_post_ttp_refresh_vendors', [__CLASS__, 'refresh_vendors']);
         add_action('admin_post_ttp_test_airbase', [__CLASS__, 'test_airbase_connection']);
     }
 
     public static function register_menu() {
         add_menu_page(
-            'Treasury Tools',
-            'Treasury Tools',
+            'Treasury Vendors',
+            'Treasury Vendors',
             'manage_options',
             'treasury-tools',
             [__CLASS__, 'render_page'],
@@ -31,15 +29,6 @@ class TTP_Admin {
             'manage_options',
             'treasury-airbase-settings',
             [__CLASS__, 'render_airbase_settings']
-        );
-
-        add_submenu_page(
-            'treasury-tools',
-            'Vendors',
-            'Vendors',
-            'manage_options',
-            'treasury-vendors',
-            [__CLASS__, 'render_vendors_page']
         );
     }
 
@@ -107,114 +96,12 @@ class TTP_Admin {
         <?php
     }
 
-    public static function render_vendors_page() {
-        if (!current_user_can('manage_options')) {
-            return;
-        }
-
-        if (isset($_GET['refreshed'])) {
-            echo '<div class="notice notice-success is-dismissible"><p>' . esc_html__('Vendor cache refreshed.', 'treasury-tech-portal') . '</p></div>';
-        }
-
-        $vendors = TTP_Data::get_all_vendors();
-        ?>
-        <div class="wrap">
-            <h1><?php esc_html_e('Vendors', 'treasury-tech-portal'); ?></h1>
-            <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
-                <?php wp_nonce_field('ttp_refresh_vendors'); ?>
-                <input type="hidden" name="action" value="ttp_refresh_vendors" />
-                <?php submit_button(__('Refresh Vendors', 'treasury-tech-portal')); ?>
-            </form>
-            <table class="widefat striped">
-                <thead>
-                    <tr>
-                        <th><?php esc_html_e('ID', 'treasury-tech-portal'); ?></th>
-                        <th><?php esc_html_e('Name', 'treasury-tech-portal'); ?></th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <?php if (!empty($vendors)) : ?>
-                        <?php foreach ($vendors as $vendor) : ?>
-                            <tr>
-                                <td><?php echo esc_html($vendor['id'] ?? ''); ?></td>
-                                <td><?php echo esc_html($vendor['name'] ?? ''); ?></td>
-                            </tr>
-                        <?php endforeach; ?>
-                    <?php else : ?>
-                        <tr>
-                            <td colspan="2"><?php esc_html_e('No vendors found.', 'treasury-tech-portal'); ?></td>
-                        </tr>
-                    <?php endif; ?>
-                </tbody>
-            </table>
-        </div>
-        <?php
-    }
-
     public static function render_page() {
         if (!current_user_can('manage_options')) {
             return;
         }
-        $tools = TTP_Data::get_all_tools();
-
-        $sort = isset($_GET['sort']) ? sanitize_text_field($_GET['sort']) : '';
-        if ($sort === 'name') {
-            usort($tools, function($a, $b) {
-                return strcasecmp($a['name'] ?? '', $b['name'] ?? '');
-            });
-        } elseif ($sort === 'category') {
-            usort($tools, function($a, $b) {
-                return strcasecmp($a['category'] ?? '', $b['category'] ?? '');
-            });
-        }
-
+        $vendors = TTP_Data::get_all_vendors();
         include dirname(__DIR__) . '/templates/admin-page.php';
-    }
-
-    public static function save_tool() {
-        if (!current_user_can('manage_options')) {
-            wp_die('Unauthorized');
-        }
-        check_admin_referer('ttp_save_tool');
-
-        $tools = TTP_Data::get_all_tools();
-        $index = isset($_POST['index']) ? absint($_POST['index']) : null;
-
-        $tool = [
-            'name'       => sanitize_text_field($_POST['name'] ?? ''),
-            'category'   => sanitize_text_field($_POST['category'] ?? ''),
-            'desc'       => sanitize_textarea_field($_POST['desc'] ?? ''),
-            'features'   => array_filter(array_map('sanitize_text_field', explode("\n", $_POST['features'] ?? ''))),
-            'target'     => sanitize_text_field($_POST['target'] ?? ''),
-            'videoUrl'   => esc_url_raw($_POST['videoUrl'] ?? ''),
-            'websiteUrl' => esc_url_raw($_POST['websiteUrl'] ?? ''),
-            'logoUrl'    => esc_url_raw($_POST['logoUrl'] ?? ''),
-        ];
-
-        if ($index === null) {
-            $tools[] = $tool;
-        } else {
-            $tools[$index] = $tool;
-        }
-
-        TTP_Data::save_tools($tools);
-        wp_redirect(admin_url('admin.php?page=treasury-tools&updated=1'));
-        exit;
-    }
-
-    public static function delete_tool() {
-        if (!current_user_can('manage_options')) {
-            wp_die('Unauthorized');
-        }
-        check_admin_referer('ttp_delete_tool');
-        $index = absint($_GET['index']);
-        $tools = TTP_Data::get_all_tools();
-        if (isset($tools[$index])) {
-            unset($tools[$index]);
-            TTP_Data::save_tools(array_values($tools));
-        }
-        wp_redirect(admin_url('admin.php?page=treasury-tools&deleted=1'));
-        exit;
     }
 
     public static function refresh_vendors() {
@@ -223,7 +110,7 @@ class TTP_Admin {
         }
         check_admin_referer('ttp_refresh_vendors');
         TTP_Data::refresh_vendor_cache();
-        wp_redirect(admin_url('admin.php?page=treasury-vendors&refreshed=1'));
+        wp_redirect(admin_url('admin.php?page=treasury-tools&refreshed=1'));
         exit;
     }
 

--- a/templates/admin-page.php
+++ b/templates/admin-page.php
@@ -1,142 +1,21 @@
 <?php if (!defined('ABSPATH')) exit; ?>
 <div class="wrap treasury-portal-admin">
-    <style>
-        .treasury-portal-admin__table-wrapper {
-            overflow-x: auto;
-        }
-
-        .treasury-portal-admin__table {
-            width: 100%;
-        }
-
-        @media (max-width: 768px) {
-            .treasury-portal-admin__table thead {
-                display: none;
-            }
-
-            .treasury-portal-admin__table tr {
-                display: block;
-                border-bottom: 1px solid #ccc;
-                margin-bottom: 10px;
-            }
-
-            .treasury-portal-admin__table td {
-                display: flex;
-                justify-content: space-between;
-                align-items: center;
-                padding: 8px;
-            }
-
-            .treasury-portal-admin__table td::before {
-                content: attr(data-label);
-                font-weight: 600;
-                margin-right: 10px;
-            }
-        }
-    </style>
-    <h1>Treasury Tools</h1>
-    <?php $current_sort = isset($_GET['sort']) ? sanitize_text_field($_GET['sort']) : ''; ?>
-    <form method="get" style="margin-bottom:10px;">
-        <input type="hidden" name="page" value="treasury-tools">
-        <label for="ttp-sort">Sort By:</label>
-        <select name="sort" id="ttp-sort" onchange="this.form.submit()">
-            <option value="" <?php selected($current_sort, ''); ?>>Default</option>
-            <option value="name" <?php selected($current_sort, 'name'); ?>>Name</option>
-            <option value="category" <?php selected($current_sort, 'category'); ?>>Category</option>
-        </select>
+    <h1><?php esc_html_e('Vendors', 'treasury-tech-portal'); ?></h1>
+    <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
+        <?php wp_nonce_field('ttp_refresh_vendors'); ?>
+        <input type="hidden" name="action" value="ttp_refresh_vendors" />
+        <?php submit_button(__('Refresh Vendors', 'treasury-tech-portal')); ?>
     </form>
-    <?php if (!empty($_GET['updated'])): ?>
-        <div class="updated notice"><p>Tool saved.</p></div>
+    <?php if (isset($_GET['refreshed'])) : ?>
+        <div class="notice notice-success is-dismissible"><p><?php esc_html_e('Vendor cache refreshed.', 'treasury-tech-portal'); ?></p></div>
     <?php endif; ?>
-    <?php if (!empty($_GET['deleted'])): ?>
-        <div class="updated notice"><p>Tool deleted.</p></div>
+    <?php if (!empty($vendors)) : ?>
+        <ul>
+            <?php foreach ($vendors as $vendor) : ?>
+                <li><?php echo esc_html($vendor['id'] ?? ''); ?> - <?php echo esc_html($vendor['name'] ?? ''); ?></li>
+            <?php endforeach; ?>
+        </ul>
+    <?php else : ?>
+        <p><?php esc_html_e('No vendors found.', 'treasury-tech-portal'); ?></p>
     <?php endif; ?>
-
-    <div class="treasury-portal-admin__table-wrapper">
-        <table class="widefat treasury-portal-admin__table">
-            <thead>
-                <tr>
-                    <th>Name</th>
-                    <th>Category</th>
-                    <th>Actions</th>
-                </tr>
-            </thead>
-            <tbody>
-                <?php foreach ($tools as $i => $tool): ?>
-                    <tr>
-                        <td data-label="Name"><?php echo esc_html($tool['name']); ?></td>
-                        <td data-label="Category"><?php echo esc_html($tool['category']); ?></td>
-                        <td data-label="Actions">
-                            <a href="#" class="edit-tool" data-index="<?php echo $i; ?>">Edit</a> |
-                            <a href="<?php echo wp_nonce_url(admin_url('admin-post.php?action=ttp_delete_tool&index=' . $i), 'ttp_delete_tool'); ?>" onclick="return confirm('Delete this tool?');">Delete</a>
-                        </td>
-                    </tr>
-                <?php endforeach; ?>
-            </tbody>
-        </table>
-    </div>
-
-    <h2 id="add-new-tool">Add / Edit Tool</h2>
-    <form method="post" action="<?php echo admin_url('admin-post.php'); ?>">
-        <?php wp_nonce_field('ttp_save_tool'); ?>
-        <input type="hidden" name="action" value="ttp_save_tool">
-        <input type="hidden" name="index" id="tool-index">
-        <table class="form-table">
-            <tr>
-                <th><label for="tool-name">Name</label></th>
-                <td><input name="name" id="tool-name" type="text" class="regular-text" required></td>
-            </tr>
-            <tr>
-                <th><label for="tool-category">Category</label></th>
-                <td><input name="category" id="tool-category" type="text" class="regular-text" required></td>
-            </tr>
-            <tr>
-                <th><label for="tool-desc">Description</label></th>
-                <td><textarea name="desc" id="tool-desc" class="large-text"></textarea></td>
-            </tr>
-            <tr>
-                <th><label for="tool-features">Features (one per line)</label></th>
-                <td><textarea name="features" id="tool-features" class="large-text"></textarea></td>
-            </tr>
-            <tr>
-                <th><label for="tool-target">Target</label></th>
-                <td><input name="target" id="tool-target" type="text" class="regular-text"></td>
-            </tr>
-            <tr>
-                <th><label for="tool-video">Video URL</label></th>
-                <td><input name="videoUrl" id="tool-video" type="url" class="regular-text"></td>
-            </tr>
-            <tr>
-                <th><label for="tool-website">Website URL</label></th>
-                <td><input name="websiteUrl" id="tool-website" type="url" class="regular-text"></td>
-            </tr>
-            <tr>
-                <th><label for="tool-logo">Logo URL</label></th>
-                <td><input name="logoUrl" id="tool-logo" type="url" class="regular-text"></td>
-            </tr>
-        </table>
-        <?php submit_button('Save Tool'); ?>
-    </form>
 </div>
-<script>
-(function(){
-    const tools = <?php echo wp_json_encode($tools); ?>;
-    document.querySelectorAll('.edit-tool').forEach(link => {
-        link.addEventListener('click', function(e){
-            e.preventDefault();
-            const index = parseInt(this.dataset.index);
-            const tool = tools[index];
-            document.getElementById('tool-index').value = index;
-            document.getElementById('tool-name').value = tool.name;
-            document.getElementById('tool-category').value = tool.category;
-            document.getElementById('tool-desc').value = tool.desc;
-            document.getElementById('tool-features').value = (tool.features || []).join('\n');
-            document.getElementById('tool-target').value = tool.target || '';
-            document.getElementById('tool-video').value = tool.videoUrl || '';
-            document.getElementById('tool-website').value = tool.websiteUrl || '';
-            document.getElementById('tool-logo').value = tool.logoUrl || '';
-            location.hash = 'add-new-tool';
-        });
-    });
-})();
-</script>


### PR DESCRIPTION
## Summary
- remove tool CRUD hooks and menu entries
- show read-only vendor list with refresh action in admin

## Testing
- `scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c20e2639d08331b3b2a5b2042d57fc