### PR TITLE
Improve mobile filter checkbox layout and search field spacing

### DIFF
--- a/assets/css/treasury-portal.css
+++ b/assets/css/treasury-portal.css
@@ -1749,6 +1749,27 @@
             line-height: 1.2;
         }
 
+        @media (max-width: 768px) {
+            .treasury-portal .checkbox-item {
+                flex-direction: column;
+                align-items: flex-start;
+            }
+
+            .treasury-portal .checkbox-item label {
+                display: block;
+                width: 100%;
+            }
+
+            .treasury-portal .search-container {
+                width: 100%;
+                padding: 0;
+            }
+
+            .treasury-portal .search-input {
+                padding: 8px 12px 8px 40px;
+            }
+        }
+
         .treasury-portal .view-options {
             display: grid;
             grid-template-columns: 1fr 1fr;


### PR DESCRIPTION
## Summary
- Adjust mobile filter checkboxes to stack vertically with full-width labels
- Tighten mobile search field padding so controls fit within the viewport

## Testing
- `scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c4be49202c83319828840b9a4b19b2