### PR TITLE
Display visible product count on mobile

### DIFF
--- a/assets/css/treasury-portal.css
+++ b/assets/css/treasury-portal.css
@@ -217,6 +217,10 @@
             transition: background 0.3s ease, transform 0.2s ease;
         }
 
+        .treasury-portal .mobile-product-count {
+            display: none;
+        }
+
         .treasury-portal .business-case-builder__link:hover {
             background: linear-gradient(135deg, #8f47f6, #7216f4);
             transform: translateY(-1px);
@@ -227,6 +231,15 @@
                 width: 100%;
                 display: flex;
                 justify-content: center;
+                align-items: center;
+            }
+
+            .treasury-portal .mobile-product-count {
+                display: inline-block;
+                margin-left: 8px;
+                font-size: 0.9rem;
+                font-weight: 600;
+                color: #7216f4;
             }
         }
 

--- a/assets/js/treasury-portal.js
+++ b/assets/js/treasury-portal.js
@@ -1817,6 +1817,11 @@ document.addEventListener('DOMContentLoaded', async () => {
                     totalTools.textContent = filtersActive ? visibleTotal : this.TREASURY_TOOLS.length;
                 }
 
+                const mobileProductCount = document.getElementById('mobileProductCount');
+                if (mobileProductCount) {
+                    mobileProductCount.textContent = filtersActive ? visibleTotal : this.TREASURY_TOOLS.length;
+                }
+
                 const totalCategories = document.getElementById('totalCategories');
                 if (totalCategories) {
                     if (filtersActive) {
@@ -1848,6 +1853,11 @@ document.addEventListener('DOMContentLoaded', async () => {
                 const totalTools = document.getElementById('totalTools');
                 if (totalTools) {
                     totalTools.textContent = this.TREASURY_TOOLS.length;
+                }
+
+                const mobileProductCount = document.getElementById('mobileProductCount');
+                if (mobileProductCount) {
+                    mobileProductCount.textContent = this.TREASURY_TOOLS.length;
                 }
 
                 const totalCategories = document.getElementById('totalCategories');

--- a/includes/shortcode.php
+++ b/includes/shortcode.php
@@ -66,6 +66,7 @@ $category_meta = array(
 
                 <div class="business-case-builder">
                     <a class="business-case-builder__link" href="/rtbcb/" target="_blank" rel="noopener noreferrer">Business Case Builder</a>
+                    <span id="mobileProductCount" class="mobile-product-count"></span>
                 </div>
 
                 <div class="intro-video-target" data-video-src="<?php echo esc_url($video_url); ?>" data-poster="<?php echo esc_url($poster_url); ?>" style="display:none;"></div>

--- a/tests/mobile-product-count.test.js
+++ b/tests/mobile-product-count.test.js
@@ -1,0 +1,34 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { JSDOM } = require('jsdom');
+const fs = require('fs');
+
+const script = fs.readFileSync('assets/js/treasury-portal.js', 'utf8');
+
+test('updateVisibleCounts updates mobile product count', () => {
+  const dom = new JSDOM(`
+    <div id="mobileProductCount"></div>
+    <div id="totalTools"></div>
+  `, { runScripts: 'outside-only' });
+  const { window } = dom;
+  global.window = window;
+  global.document = window.document;
+  window.ResizeObserver = class { constructor() {} observe() {} };
+  window.MutationObserver = class { constructor() {} observe() {} };
+
+  window.eval(`${script}\nwindow.TreasuryTechPortal = TreasuryTechPortal;`);
+  const TreasuryTechPortal = window.TreasuryTechPortal;
+  const portal = Object.create(TreasuryTechPortal.prototype);
+
+  portal.enabledCategories = [];
+  portal.filteredTools = [{}, {}];
+  portal.TREASURY_TOOLS = [{}, {}, {}];
+  portal.allCategories = [];
+  portal.searchTerm = 'a';
+  portal.advancedFilters = { features: [], hasVideo: false, regions: [], categories: [], subcategories: [] };
+
+  portal.updateVisibleCounts();
+
+  assert.equal(document.getElementById('mobileProductCount').textContent, '2');
+  assert.equal(document.getElementById('totalTools').textContent, '2');
+});


### PR DESCRIPTION
## Summary
- Show mobile product count next to Business Case Builder link
- Style and populate new count element
- Test updateVisibleCounts() writes count to mobile display

## Testing
- `npm test`
- `scripts/test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c4c35a2b0c83319adca9914e826615