### PR TITLE
Display mobile tool count next to Business Case Builder

### DIFF
--- a/assets/css/treasury-portal.css
+++ b/assets/css/treasury-portal.css
@@ -222,11 +222,29 @@
             transform: translateY(-1px);
         }
 
+        .treasury-portal .mobile-product-count {
+            display: none;
+        }
+
         @media (max-width: 768px) {
             .treasury-portal .business-case-builder {
                 width: 100%;
                 display: flex;
                 justify-content: center;
+                align-items: center;
+            }
+
+            .treasury-portal .mobile-product-count {
+                display: inline-block;
+                margin-left: 8px;
+                font-size: 0.75rem;
+                font-weight: 600;
+                line-height: 1;
+                padding: 2px 8px;
+                color: #fff;
+                background: #7216f4;
+                border-radius: 9999px;
+                vertical-align: middle;
             }
         }
 

--- a/assets/js/treasury-portal.js
+++ b/assets/js/treasury-portal.js
@@ -1817,6 +1817,11 @@ document.addEventListener('DOMContentLoaded', async () => {
                     totalTools.textContent = filtersActive ? visibleTotal : this.TREASURY_TOOLS.length;
                 }
 
+                const mobileCount = document.getElementById('mobileProductCount');
+                if (mobileCount) {
+                    mobileCount.textContent = filtersActive ? visibleTotal : this.TREASURY_TOOLS.length;
+                }
+
                 const totalCategories = document.getElementById('totalCategories');
                 if (totalCategories) {
                     if (filtersActive) {
@@ -1848,6 +1853,11 @@ document.addEventListener('DOMContentLoaded', async () => {
                 const totalTools = document.getElementById('totalTools');
                 if (totalTools) {
                     totalTools.textContent = this.TREASURY_TOOLS.length;
+                }
+
+                const mobileCount = document.getElementById('mobileProductCount');
+                if (mobileCount) {
+                    mobileCount.textContent = this.TREASURY_TOOLS.length;
                 }
 
                 const totalCategories = document.getElementById('totalCategories');

--- a/includes/shortcode.php
+++ b/includes/shortcode.php
@@ -66,6 +66,7 @@ $category_meta = array(
 
                 <div class="business-case-builder">
                     <a class="business-case-builder__link" href="/rtbcb/" target="_blank" rel="noopener noreferrer">Business Case Builder</a>
+                    <span id="mobileProductCount" class="mobile-product-count" aria-live="polite"></span>
                 </div>
 
                 <div class="intro-video-target" data-video-src="<?php echo esc_url($video_url); ?>" data-poster="<?php echo esc_url($poster_url); ?>" style="display:none;"></div>

--- a/tests/mobile-product-count.test.js
+++ b/tests/mobile-product-count.test.js
@@ -1,0 +1,64 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { JSDOM } = require('jsdom');
+const fs = require('fs');
+
+const script = fs.readFileSync('assets/js/treasury-portal.js', 'utf8');
+
+test('updateVisibleCounts updates mobile product count with filtered length', () => {
+  const dom = new JSDOM(`
+    <div class="treasury-portal"></div>
+    <span id="mobileProductCount"></span>
+    <div id="count-CASH"></div>
+    <div id="count-LITE"></div>
+    <div id="totalTools"></div>
+    <div id="totalCategories"></div>
+  `, { runScripts: 'outside-only' });
+  const { window } = dom;
+  global.window = window;
+  global.document = window.document;
+  window.ResizeObserver = class { constructor() {} observe() {} };
+  window.MutationObserver = class { constructor() {} observe() {} };
+
+  window.TTP_DATA = {
+    available_categories: ['CASH', 'LITE'],
+    enabled_categories: ['CASH', 'LITE'],
+    category_labels: { CASH: 'Cash', LITE: 'TMS-Lite' }
+  };
+
+  const origDocAdd = window.document.addEventListener.bind(window.document);
+  window.document.addEventListener = (type, listener, options) => {
+    if (type !== 'DOMContentLoaded') {
+      origDocAdd(type, listener, options);
+    }
+  };
+  const origWinAdd = window.addEventListener.bind(window);
+  window.addEventListener = (type, listener, options) => {
+    if (type !== 'load') {
+      origWinAdd(type, listener, options);
+    }
+  };
+
+  window.eval(`${script}\nwindow.TreasuryTechPortal = TreasuryTechPortal;`);
+  const TreasuryTechPortal = window.TreasuryTechPortal;
+  const portal = Object.create(TreasuryTechPortal.prototype);
+
+  portal.enabledCategories = ['CASH', 'LITE'];
+  portal.allCategories = ['CASH', 'LITE'];
+  portal.filteredTools = [
+    { category: 'CASH', categoryName: 'Cash' },
+    { category: 'LITE', categoryName: 'TMS-Lite' }
+  ];
+  portal.TREASURY_TOOLS = [
+    { category: 'CASH', categoryName: 'Cash' },
+    { category: 'LITE', categoryName: 'TMS-Lite' },
+    { category: 'CASH', categoryName: 'Cash' }
+  ];
+  portal.searchTerm = 'x';
+  portal.advancedFilters = { features: [], hasVideo: false, regions: [], categories: [], subcategories: [] };
+
+  portal.updateVisibleCounts();
+
+  const mobileCount = document.getElementById('mobileProductCount').textContent;
+  assert.equal(mobileCount, '2');
+});


### PR DESCRIPTION
## Summary
- Show a filtered tool count beside the Business Case Builder link on mobile.
- Style the mobile count and update it whenever filters change.
- Test that updateVisibleCounts populates the mobile count correctly.

## Testing
- `npm test`
- `scripts/test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c4c35a2b0c83319adca9914e826615