### PR TITLE
feat: improve mobile tool count accessibility

### DIFF
--- a/assets/css/treasury-portal.css
+++ b/assets/css/treasury-portal.css
@@ -9,6 +9,18 @@
             box-sizing: border-box;
         }
 
+    .treasury-portal .sr-only {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border: 0;
+        }
+
         /* Base portal styles */
     .treasury-portal {
             font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;

--- a/assets/js/treasury-portal.js
+++ b/assets/js/treasury-portal.js
@@ -1819,7 +1819,9 @@ document.addEventListener('DOMContentLoaded', async () => {
 
                 const mobileProductCount = document.getElementById('mobileProductCount');
                 if (mobileProductCount) {
-                    mobileProductCount.textContent = filtersActive ? visibleTotal : this.TREASURY_TOOLS.length;
+                    const count = filtersActive ? visibleTotal : this.TREASURY_TOOLS.length;
+                    mobileProductCount.textContent = count;
+                    mobileProductCount.setAttribute('aria-label', `${count} visible tools`);
                 }
 
                 const totalCategories = document.getElementById('totalCategories');
@@ -1857,7 +1859,9 @@ document.addEventListener('DOMContentLoaded', async () => {
 
                 const mobileProductCount = document.getElementById('mobileProductCount');
                 if (mobileProductCount) {
-                    mobileProductCount.textContent = this.TREASURY_TOOLS.length;
+                    const count = this.TREASURY_TOOLS.length;
+                    mobileProductCount.textContent = count;
+                    mobileProductCount.setAttribute('aria-label', `${count} visible tools`);
                 }
 
                 const totalCategories = document.getElementById('totalCategories');

--- a/includes/shortcode.php
+++ b/includes/shortcode.php
@@ -66,7 +66,8 @@ $category_meta = array(
 
                 <div class="business-case-builder">
                     <a class="business-case-builder__link" href="/rtbcb/" target="_blank" rel="noopener noreferrer">Business Case Builder</a>
-                    <span id="mobileProductCount" class="mobile-product-count"></span>
+                    <span id="mobileProductCount" class="mobile-product-count" aria-label="0 visible tools"></span>
+                    <span class="sr-only"> tools</span>
                 </div>
 
                 <div class="intro-video-target" data-video-src="<?php echo esc_url($video_url); ?>" data-poster="<?php echo esc_url($poster_url); ?>" style="display:none;"></div>

--- a/tests/mobile-product-count.test.js
+++ b/tests/mobile-product-count.test.js
@@ -7,7 +7,8 @@ const script = fs.readFileSync('assets/js/treasury-portal.js', 'utf8');
 
 test('updateVisibleCounts updates mobile product count', () => {
   const dom = new JSDOM(`
-    <div id="mobileProductCount"></div>
+    <div id="mobileProductCount" aria-label="0 visible tools"></div>
+    <span class="sr-only"> tools</span>
     <div id="totalTools"></div>
   `, { runScripts: 'outside-only' });
   const { window } = dom;
@@ -29,6 +30,8 @@ test('updateVisibleCounts updates mobile product count', () => {
 
   portal.updateVisibleCounts();
 
-  assert.equal(document.getElementById('mobileProductCount').textContent, '2');
+  const mobileCount = document.getElementById('mobileProductCount');
+  assert.equal(mobileCount.textContent, '2');
+  assert.equal(mobileCount.getAttribute('aria-label'), '2 visible tools');
   assert.equal(document.getElementById('totalTools').textContent, '2');
 });


### PR DESCRIPTION
## Summary
- add aria-label and screen-reader text for mobile tool count
- keep aria label synced with visible tool count
- hide assistive text via sr-only utility class

## Testing
- `npm test`
- `./scripts/test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c4d280d01c8331b5bef3210b5f1323