### PR TITLE
Increase mobile tool logo size for mobile breakpoint

### DIFF
--- a/assets/css/treasury-portal.css
+++ b/assets/css/treasury-portal.css
@@ -902,9 +902,9 @@
 
 @media (max-width: 768px) {
     .treasury-portal .tool-logo-inline {
-        width: 48px;
-        height: 48px;
-        margin: 0 12px 0 8px;
+        width: 60px;
+        height: 60px;
+        margin: 0 14px 0 10px;
     }
 }
 


### PR DESCRIPTION
## Summary
- enlarge tool logo size in mobile breakpoint to 60px
- adjust margins for consistent spacing

## Testing
- `scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c4eae1faac8331b1b89735020e515d