### PR TITLE
feat: enlarge modal tool logo on mobile

### DIFF
--- a/assets/css/treasury-portal.css
+++ b/assets/css/treasury-portal.css
@@ -1351,15 +1351,15 @@
             }
 
             .treasury-portal .modal-tool-logo {
-                width: 90px;
-                height: 90px;
-                margin: 0 16px 0 8px;
+                width: 110px;
+                height: 110px;
+                margin: 0 12px 0 8px;
             }
 
             .treasury-portal .modal-title-group .modal-tool-logo {
-                width: 90px;
-                height: 90px;
-                margin: 0 16px 0 8px;
+                width: 110px;
+                height: 110px;
+                margin: 0 12px 0 8px;
             }
         }
 


### PR DESCRIPTION
## Summary
- increase mobile modal tool logo to 110px and adjust margins for spacing

## Testing
- `./scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c4eae6c58c8331b0bbd541d28f2b40